### PR TITLE
Handle revisions with no revprops

### DIFF
--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -523,9 +523,9 @@ int SvnRevision::fetchRevProps()
     svn_string_t *svndate = (svn_string_t*)apr_hash_get(revprops, "svn:date", APR_HASH_KEY_STRING);
     svn_string_t *svnlog = (svn_string_t*)apr_hash_get(revprops, "svn:log", APR_HASH_KEY_STRING);
 
-    log = svnlog->data;
+    log = svnlog ? svnlog->data : 0;
     authorident = svnauthor ? identities.value(svnauthor->data) : QByteArray();
-    epoch = get_epoch(svndate->data);
+    epoch = svndate ? get_epoch(svndate->data) : 0;
     if (authorident.isEmpty()) {
         if (!svnauthor || svn_string_isempty(svnauthor))
             authorident = "nobody <nobody@localhost>";

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -523,7 +523,10 @@ int SvnRevision::fetchRevProps()
     svn_string_t *svndate = (svn_string_t*)apr_hash_get(revprops, "svn:date", APR_HASH_KEY_STRING);
     svn_string_t *svnlog = (svn_string_t*)apr_hash_get(revprops, "svn:log", APR_HASH_KEY_STRING);
 
-    log = svnlog ? svnlog->data : 0;
+    if (svnlog)
+        log = svnlog->data;
+    else
+        log.clear();
     authorident = svnauthor ? identities.value(svnauthor->data) : QByteArray();
     epoch = svndate ? get_epoch(svndate->data) : 0;
     if (authorident.isEmpty()) {


### PR DESCRIPTION
Sometimes some revisions are filtered out by authz rules on the server,
and when you create a mirror with svnsync, you end up with an empty
revision that has no revprops whatsoever.  This means svnlog, svndate
and svnauthor are all NULL.  This used to cause segfaults.

Here's some context: http://svn.haxx.se/users/archive-2013-02/0160.shtml