### PR TITLE
Make 'repository' and 'prefix' inside 'repository' work like expected again

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -199,7 +199,7 @@ int main(int argc, char **argv)
  retry:
     int min_rev = 1;
     foreach (Rules::Repository rule, rulesList.allRepositories()) {
-        Repository *repo = new Repository(rule);
+        Repository *repo = createRepository(rule, repositories);
         if (!repo)
             return EXIT_FAILURE;
         repositories.insert(rule.name, repo);

--- a/src/repository.h
+++ b/src/repository.h
@@ -91,115 +91,54 @@ public:
     }
 };
 
-
 class Repository
 {
 public:
     class Transaction
     {
         Q_DISABLE_COPY(Transaction)
-        friend class Repository;
-
-        Repository *repository;
-        QByteArray branch;
-        QByteArray svnprefix;
-        QByteArray author;
-        QByteArray log;
-        uint datetime;
-        int revnum;
-
-        QVector<int> merges;
-
-        QStringList deletedFiles;
-        QByteArray modifiedFiles;
-
-        inline Transaction() {}
+    protected:
+        Transaction() {}
     public:
-        ~Transaction();
-        void commit();
+        virtual ~Transaction() {}
+        virtual void commit() = 0;
 
-        void setAuthor(const QByteArray &author);
-        void setDateTime(uint dt);
-        void setLog(const QByteArray &log);
+        virtual void setAuthor(const QByteArray &author) = 0;
+        virtual void setDateTime(uint dt) = 0;
+        virtual void setLog(const QByteArray &log) = 0;
 
-        void noteCopyFromBranch (const QString &prevbranch, int revFrom);
+        virtual void noteCopyFromBranch (const QString &prevbranch, int revFrom) = 0;
 
-        void deleteFile(const QString &path);
-        QIODevice *addFile(const QString &path, int mode, qint64 length);
+        virtual void deleteFile(const QString &path) = 0;
+        virtual QIODevice *addFile(const QString &path, int mode, qint64 length) = 0;
 
-        void commitNote(const QByteArray &noteText, bool append,
-                        const QByteArray &commit = QByteArray());
+        virtual void commitNote(const QByteArray &noteText, bool append,
+                                const QByteArray &commit = QByteArray()) = 0;
     };
-    Repository(const Rules::Repository &rule);
-    int setupIncremental(int &cutoff);
-    void restoreLog();
-    ~Repository();
+    virtual int setupIncremental(int &cutoff) = 0;
+    virtual void restoreLog() = 0;
+    virtual ~Repository() {}
 
-    void reloadBranches();
-    int createBranch(const QString &branch, int revnum,
-                     const QString &branchFrom, int revFrom);
-    int deleteBranch(const QString &branch, int revnum);
-    Repository::Transaction *newTransaction(const QString &branch, const QString &svnprefix, int revnum);
+    virtual void reloadBranches() = 0;
+    virtual int createBranch(const QString &branch, int revnum,
+                             const QString &branchFrom, int revFrom) = 0;
+    virtual int deleteBranch(const QString &branch, int revnum) = 0;
+    virtual Repository::Transaction *newTransaction(const QString &branch, const QString &svnprefix, int revnum) = 0;
 
-    void createAnnotatedTag(const QString &name, const QString &svnprefix, int revnum,
-                            const QByteArray &author, uint dt,
-                            const QByteArray &log);
-    void finalizeTags();
-    void commit();
+    virtual void createAnnotatedTag(const QString &name, const QString &svnprefix, int revnum,
+                                    const QByteArray &author, uint dt,
+                                    const QByteArray &log) = 0;
+    virtual void finalizeTags() = 0;
+    virtual void commit() = 0;
 
     static QByteArray formatMetadataMessage(const QByteArray &svnprefix, int revnum,
                                             const QByteArray &tag = QByteArray());
 
-    bool branchExists(const QString& branch) const;
-    const QByteArray branchNote(const QString& branch) const;
-    void setBranchNote(const QString& branch, const QByteArray& noteText);
-
-private:
-    struct Branch
-    {
-        int created;
-        QVector<int> commits;
-        QVector<int> marks;
-        QByteArray note;
-    };
-    struct AnnotatedTag
-    {
-        QString supportingRef;
-        QByteArray svnprefix;
-        QByteArray author;
-        QByteArray log;
-        uint dt;
-        int revnum;
-    };
-
-    QHash<QString, Branch> branches;
-    QHash<QString, AnnotatedTag> annotatedTags;
-    QString name;
-    QString prefix;
-    LoggingQProcess fastImport;
-    int commitCount;
-    int outstandingTransactions;
-    QByteArray deletedBranches;
-    QByteArray resetBranches;
-
-    /* starts at 0, and counts up.  */
-    int last_commit_mark;
-
-    /* starts at maxMark and counts down. Reset after each SVN revision */
-    int next_file_mark;
-
-    bool processHasStarted;
-
-    void startFastImport();
-    void closeFastImport();
-
-    // called when a transaction is deleted
-    void forgetTransaction(Transaction *t);
-
-    int resetBranch(const QString &branch, int revnum, int mark, const QByteArray &resetTo, const QByteArray &comment);
-    int markFrom(const QString &branchFrom, int branchRevNum, QByteArray &desc);
-
-    friend class ProcessCache;
-    Q_DISABLE_COPY(Repository)
+    virtual bool branchExists(const QString& branch) const = 0;
+    virtual const QByteArray branchNote(const QString& branch) const = 0;
+    virtual void setBranchNote(const QString& branch, const QByteArray& noteText) = 0;
 };
+
+Repository *createRepository(const Rules::Repository &rule, const QHash<QString, Repository *> &repositories);
+
 #endif

--- a/src/ruleparser.cpp
+++ b/src/ruleparser.cpp
@@ -207,6 +207,18 @@ void Rules::load(const QString &filename)
                     repo.prefix = matchPrefixLine.cap(1);
                     continue;
                 } else if (line == "end repository") {
+                    if (!repo.forwardTo.isEmpty()
+                        && !repo.description.isEmpty()) {
+
+                        qFatal("Specifing repository and description on repository is invalid on line %d", lineNumber);
+                    }
+
+                    if (!repo.forwardTo.isEmpty()
+                        && !repo.branches.isEmpty()) {
+
+                        qFatal("Specifing repository and branches on repository is invalid on line %d", lineNumber);
+                    }
+
                     m_repositories += repo;
                     {
                         // clear out 'repo'


### PR DESCRIPTION
The change 4686434f149a7c6c3f6aef6f0d9f394990bc87db breaks the functionality of

~~~
create repository foo
    repository bar
    prefix baz/
end repository
~~~

Which should forward stuff that is attributed to repository `foo` to repository `bar` instead with a prefix of `baz/`.
Now the `prefix` rule is ignored and the `repository` rules value is taken as prefix which does not make too much sense and breaks the functionality of those rules that was intended with commit
008b28e0f4c48de8d740c51c053020d1a36315bf.

This PR tries to fix this behaviour to get the original meaning of the rules back.