### PR TITLE
When recursing into a directory, also match files, not only directories

### DIFF
--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -869,8 +869,6 @@ int SvnRevision::recurse(const char *path, const svn_fs_path_change_t *change,
         void *value;
         apr_hash_this(i, &vkey, NULL, &value);
         svn_fs_dirent_t *dirent = reinterpret_cast<svn_fs_dirent_t *>(value);
-        if (dirent->kind != svn_node_dir)
-            continue;           // not a directory, so can't recurse; skip
         map.insertMulti(QByteArray(dirent->name), dirent->kind);
     }
 


### PR DESCRIPTION
Despite the comment on the `continue` line, it makes not sense to check this here.
In the iteration below is made sure that directories get a slash appended in the end and that if no rule matched **and** it is a directory, the recursion goes on in the subdirectory.

With the lines I removed, the recursion doesn't consider the file entries and so you cannot match single files in a recursed directory.