### PR TITLE
Output the rules ordered by filename and linenumber when using --stats

### DIFF
--- a/src/ruleparser.cpp
+++ b/src/ruleparser.cpp
@@ -331,7 +331,7 @@ public:
     void ruleMatched(const Rules::Match &rule, const int rev);
     void addRule(const Rules::Match &rule);
 private:
-    QMap<QString,int> m_usedRules;
+    QMap<Rules::Match,int> m_usedRules;
 };
 
 Stats::Stats() : d(new Private())
@@ -381,29 +381,27 @@ Stats::Private::Private()
 void Stats::Private::printStats() const
 {
     printf("\nRule stats\n");
-    foreach(const QString name, m_usedRules.keys()) {
-        printf("%s was matched %i times\n", qPrintable(name), m_usedRules[name]);
+    foreach(const Rules::Match rule, m_usedRules.keys()) {
+        printf("%s was matched %i times\n", qPrintable(rule.info()), m_usedRules[rule]);
     }
 }
 
 void Stats::Private::ruleMatched(const Rules::Match &rule, const int rev)
 {
     Q_UNUSED(rev);
-    const QString name = rule.info();
-    if(!m_usedRules.contains(name)) {
-        m_usedRules.insert(name, 1);
-        qWarning() << "WARN: New match rule, should have been added when created.";
+    if(!m_usedRules.contains(rule)) {
+        m_usedRules.insert(rule, 1);
+        qWarning() << "WARN: New match rule" << rule.info() << ", should have been added when created.";
     } else {
-        m_usedRules[name]++;
+        m_usedRules[rule]++;
     }
 }
 
 void Stats::Private::addRule( const Rules::Match &rule)
 {
-    const QString name = rule.info();
-    if(m_usedRules.contains(name))
-        qWarning() << "WARN: Rule" << name << "was added multiple times.";
-    m_usedRules.insert(name, 0);
+    if(m_usedRules.contains(rule))
+        qWarning() << "WARN: Rule" << rule.info() << "was added multiple times.";
+    m_usedRules.insert(rule, 0);
 }
 
 #ifndef QT_NO_DEBUG_STREAM

--- a/src/ruleparser.h
+++ b/src/ruleparser.h
@@ -83,6 +83,11 @@ public:
         } action;
 
         Match() : minRevision(-1), maxRevision(-1), annotate(false), action(Ignore) { }
+        bool operator<(const Match other) const {
+            if (filename != other.filename)
+                return filename < other.filename;
+            return lineNumber < other.lineNumber;
+        }
         const QString info() const {
             const QString info = Rule::filename % ":" % QByteArray::number(Rule::lineNumber) % " " % rx.pattern();
             return info;


### PR DESCRIPTION
Before it was sorted by string representation which does not sort numbers correctly, but put 10 between 1 and 2.