### PR TITLE
Always mark repositories case-sensitive

### DIFF
--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -288,6 +288,10 @@ FastImportRepository::FastImportRepository(const Rules::Repository &rule)
             init.setWorkingDirectory(name);
             init.start("git", QStringList() << "--bare" << "init");
             init.waitForFinished(-1);
+            QProcess casesensitive;
+            casesensitive.setWorkingDirectory(name);
+            casesensitive.start("git", QStringList() << "config" << "core.ignorecase" << "false");
+            casesensitive.waitForFinished(-1);
             // Write description
             if (!rule.description.isEmpty()) {
                 QFile fDesc(QDir(name).filePath("description"));


### PR DESCRIPTION
This fixes a problem on platforms where git automatically defaults to
case-insensitive repositories (e.g. OS X and Windows), where case-only
renames would be simply ignored.

This would turn SVN changes such as https://trac.macports.org/changeset/153824/trunk/dports into empty Git commits when exported on an OS X machine.
