### PR TITLE
Overhauling .gitignore file generation

### DIFF
--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -642,7 +642,7 @@ Repository::Transaction *FastImportRepository::newTransaction(const QString &bra
         startFastImport();
         // write everything to disk every 10000 commits
         fastImport.write("checkpoint\n");
-        qDebug() << "checkpoint!, marks file trunkated";
+        qDebug() << "checkpoint!, marks file truncated";
     }
     outstandingTransactions++;
     return txn;

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -1059,11 +1059,10 @@ int SvnRevision::fetchUnknownProps(apr_pool_t *pool, const char *key, svn_fs_roo
     const void *propKey;
     for (hi = apr_hash_first(pool, table); hi; hi = apr_hash_next(hi)) {
         apr_hash_this(hi, &propKey, NULL, &propVal);
-        if (strcmp((char*)propKey, "svn:ignore")!=0) {
+        if (strcmp((char*)propKey, "svn:ignore")!=0 && strcmp((char*)propKey, "svn:mergeinfo") !=0) {
             qWarning() << "WARN: Unknown svn-property" << (char*)propKey << "set to" << ((svn_string_t*)propVal)->data << "for" << key;
         }
     }
 
     return EXIT_SUCCESS;
 }
-


### PR DESCRIPTION
- fix for #34, also porting svn:global-ignores to .gitignore and correctly transform SVN ignore patterns to Git ignore patterns
- fix for a typo
- do not warn about svn:mergeinfo when warning about unknown SVN properties