### PR TITLE
Various improvements (was: "Do not try to recursively dump a file")

### DIFF
--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -296,7 +296,7 @@ FastImportRepository::FastImportRepository(const Rules::Repository &rule)
             if (!rule.description.isEmpty()) {
                 QFile fDesc(QDir(name).filePath("description"));
                 if (fDesc.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
-                    fDesc.write(rule.description.toUtf8());
+                            fDesc.write(rule.description.toUtf8());
                     fDesc.putChar('\n');
                     fDesc.close();
                 }
@@ -490,7 +490,7 @@ void FastImportRepository::reloadBranches()
         if (br.marks.isEmpty() || !br.marks.last())
             continue;
 
-	reset_notes = true;
+        reset_notes = true;
 
         QByteArray branchRef = branch.toUtf8();
         if (!branchRef.startsWith("refs/"))
@@ -502,10 +502,10 @@ void FastImportRepository::reloadBranches()
     }
 
     if (reset_notes &&
-	CommandLineParser::instance()->contains("add-metadata-notes")) {
-      fastImport.write("reset refs/notes/commits\nfrom :" +
-		       QByteArray::number(maxMark + 1) +
-		       "\n");
+        CommandLineParser::instance()->contains("add-metadata-notes")) {
+        fastImport.write("reset refs/notes/commits\nfrom :" +
+                         QByteArray::number(maxMark + 1) +
+                         "\n");
     }
 }
 
@@ -744,18 +744,18 @@ FastImportRepository::msgFilter(QByteArray msg)
     QByteArray output = msg;
 
     if (CommandLineParser::instance()->contains("msg-filter")) {
-	if (filterMsg.state() == QProcess::Running)
-	    qFatal("filter process already running?");
+        if (filterMsg.state() == QProcess::Running)
+            qFatal("filter process already running?");
 
-	filterMsg.start(CommandLineParser::instance()->optionArgument("msg-filter"));
+        filterMsg.start(CommandLineParser::instance()->optionArgument("msg-filter"));
 
-	if(!(filterMsg.waitForStarted(-1)))
-	    qFatal("Failed to Start Filter %d %s", __LINE__, qPrintable(filterMsg.errorString()));
+        if(!(filterMsg.waitForStarted(-1)))
+            qFatal("Failed to Start Filter %d %s", __LINE__, qPrintable(filterMsg.errorString()));
 
-	filterMsg.write(msg);
-	filterMsg.closeWriteChannel();
-	filterMsg.waitForFinished();
-	output = filterMsg.readAllStandardOutput();
+        filterMsg.write(msg);
+        filterMsg.closeWriteChannel();
+        filterMsg.waitForFinished();
+        output = filterMsg.readAllStandardOutput();
     }
     return output;
 }
@@ -996,7 +996,7 @@ void FastImportRepository::Transaction::commit()
 
     // note some of the inferred merges
     QByteArray desc = "";
-    mark_t i = !!parentmark;	// if parentmark != 0, there's at least one parent
+    mark_t i = !!parentmark;        // if parentmark != 0, there's at least one parent
 
     if(log.contains("This commit was manufactured by cvs2svn") && merges.count() > 1) {
         qSort(merges);

--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -279,8 +279,8 @@ FastImportRepository::FastImportRepository(const Rules::Repository &rule)
     // create the default branch
     branches["master"].created = 1;
 
-    fastImport.setWorkingDirectory(name);
     if (!CommandLineParser::instance()->contains("dry-run") && !CommandLineParser::instance()->contains("create-dump")) {
+        fastImport.setWorkingDirectory(name);
         if (!QDir(name).exists()) { // repo doesn't exist yet.
             qDebug() << "Creating new repository" << name;
             QDir::current().mkpath(name);

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -1031,11 +1031,15 @@ int SvnRevision::addGitIgnore(apr_pool_t *pool, const char *key, QString path,
     QString gitIgnorePath = path + ".gitignore";
     if (content) {
         QIODevice *io = txn->addFile(gitIgnorePath, 33188, strlen(content));
-        io->write(content);
-        io->putChar('\n');
+        if (!CommandLineParser::instance()->contains("dry-run")) {
+            io->write(content);
+            io->putChar('\n');
+        }
     } else {
         QIODevice *io = txn->addFile(gitIgnorePath, 33188, 0);
-        io->putChar('\n');
+        if (!CommandLineParser::instance()->contains("dry-run")) {
+            io->putChar('\n');
+        }
     }
 
     return EXIT_SUCCESS;

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -68,12 +68,12 @@ class AprAutoPool
 public:
     inline AprAutoPool(apr_pool_t *parent = NULL)
         {
-		pool = svn_pool_create(parent);
-	}
-	inline ~AprAutoPool()
+            pool = svn_pool_create(parent);
+        }
+        inline ~AprAutoPool()
         {
-		svn_pool_destroy(pool);
-	}
+            svn_pool_destroy(pool);
+        }
 
     inline void clear() { svn_pool_clear(pool); }
     inline apr_pool_t *data() const { return pool; }


### PR DESCRIPTION
If you have a rule that matches a file, not a directory and use the `--svn-branches` parameter, svn2git tries to recursively dump the file which of course gives an error from SVN that the file is not a directory. Actually I find it even worse that svn2git just ignores the error and goes on without the file. Anyway, I fixed the routine to just dump the blob if it is not a directory.