### PR TITLE
Make git fast-import timeout configurable (#39)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -144,6 +144,7 @@ static const CommandLineOption options[] = {
     {"--empty-dirs", "Add .gitignore-file for empty dirs"},
     {"--svn-ignore", "Import svn-ignore-properties via .gitignore"},
     {"--propcheck", "Check for svn-properties except svn-ignore"},
+    {"--fast-import-timeout SECONDS", "number of seconds to wait before terminating fast-import, 0 to wait forever"},
     {"-h, --help", "show help"},
     {"-v, --version", "show version"},
     CommandLineLastOption


### PR DESCRIPTION
Very large SVN repositories, especially those which include binary
files, tend to result in very large git pack files (tens of gigabytes).

With its current approach, svn2git will wait 30 seconds (the default
timeout of waitForFinished()) for git fast-import to finish before it
terminates the git process. That default timeout is way too small for
large pack files for which the import process can take several minutes.

To work around this very long processing time, this commit adds the new
command line option "--fast-import-timeout". It allows the user to set a
custom timeout in seconds to wait for git fast-import to finish, with a
timeout of 0 meaning that svn2git will wait forever. This way even large
SVN repositories can be imported successfully.