### PR TITLE
Annotated Tags When Using Sub Paths

### DIFF
--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -675,9 +675,9 @@ void FastImportRepository::createAnnotatedTag(const QString &ref, const QString 
         tagName.remove(0, 10);
 
     if (!annotatedTags.contains(tagName))
-        printf("Creating annotated tag %s (%s)\n", qPrintable(tagName), qPrintable(ref));
+        printf("\nCreating annotated tag %s (%s) for %s\n", qPrintable(tagName), qPrintable(ref), qPrintable(name));
     else
-        printf("Re-creating annotated tag %s\n", qPrintable(tagName));
+        printf("\nRe-creating annotated tag %s for %s\n", qPrintable(tagName), qPrintable(name));
 
     AnnotatedTag &tag = annotatedTags[tagName];
     tag.supportingRef = ref;

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -934,6 +934,13 @@ int SvnRevision::exportInternal(const char *key, const svn_fs_path_change2_t *ch
         recursiveDumpDir(txn, fs, fs_root, key, path, pool, revnum, rule, matchRules, ruledebug);
     }
 
+    if (rule.annotate) {
+        // create an annotated tag
+        fetchRevProps();
+        repo->createAnnotatedTag(branch, svnprefix, revnum, authorident,
+                                 epoch, log);
+    }
+
     return EXIT_SUCCESS;
 }
 


### PR DESCRIPTION
If you combine several sub-repos from the orignal SVN repo into one Git repo
and thus deal with prefixes in the rules, the annotated tags are not created
as it never enters the part where the annotated tags are created.
The comment says it only enters that part if dealing with the whole tree.

With this PR now also for the other cases annotated tags are created properly.