### PR TITLE
Abort on conflicting ref names

### DIFF
--- a/src/repository.h
+++ b/src/repository.h
@@ -101,7 +101,7 @@ public:
         Transaction() {}
     public:
         virtual ~Transaction() {}
-        virtual void commit() = 0;
+        virtual int commit() = 0;
 
         virtual void setAuthor(const QByteArray &author) = 0;
         virtual void setDateTime(uint dt) = 0;

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -602,7 +602,8 @@ int SvnRevision::commit()
         txn->setDateTime(epoch);
         txn->setLog(log);
 
-        txn->commit();
+        if (txn->commit() != EXIT_SUCCESS)
+            return EXIT_FAILURE;
         delete txn;
     }
 


### PR DESCRIPTION
If you have a ref name refs/tags/foo you cannot create a ref refs/tags/foo/bar
and also the other way around, as for the former a file and the the latter a directory
would be created that both would be named 'foo' as long as the refs are not packed.

So check for this and abort early so that the rules can be adapted to produce proper names.