### PR TITLE
Fix for issue #43

### DIFF
--- a/tests/gebaehr-directory-replace/README.txt
+++ b/tests/gebaehr-directory-replace/README.txt
@@ -1,0 +1,32 @@
+Based on a bug report by Ge Bae: https://github.com/svn-all-fast-export/svn2git/issues/43
+
+When an svn transaction replaces an existing directory from another directory, it
+deletes any pre-existing files before the copy.
+
+svn-all-fast-export did not perform the remove and left the pre-existing files in-place.
+
+	r1:
+      A trunk/folder/file1.txt
+    r2:
+      A branches/b1 from trunk
+    r3:
+      D trunk/folder/file1.txt
+      A trunk/folder/file2.txt
+    r4:
+      A branches/b2 from trunk
+    r5:
+      # how svn log shows a replace, but it is a discrete transaction of type
+      # svn_fs_path_change_replace
+      D branches/b1/folder
+      A branches/b1/folder from trunk
+
+In the SVN repos, b1/folder contains file2.txt and not file1.txt.
+
+In a converted git repos, b1/folder would contain both file1.txt and file2.txt.
+
+The code in this folder was written with a view to constructing a general purpose
+test harness that could test more than just this one case.
+
+
+-Oliver 'kfsone' Smith <oliver@kfs.org>
+

--- a/tests/gebaehr-directory-replace/authors.txt
+++ b/tests/gebaehr-directory-replace/authors.txt
@@ -1,0 +1,1 @@
+gebaehr = Ge Bae <ge.bae@mylocaltestdomain.com>

--- a/tests/gebaehr-directory-replace/execute.sh
+++ b/tests/gebaehr-directory-replace/execute.sh
@@ -1,0 +1,135 @@
+#! /usr/bin/env bash
+
+# Deterine if we were executed or sourced.
+if [ "$_" = "${0:-}" ]; then MAIN=: ; else MAIN=/bin/false; fi
+
+# Did you ask us to clean?
+if [ "${1:-}" = "--clean" ]; then CLEAN=1; shift; fi
+
+
+##############################################################################
+# Configurables
+
+# Path to the svn-all-fast-export binary you want to test.
+SAFE_EXE="${SAFE_EXE:-../../svn-all-fast-export}"
+
+# Name of the svn dump file
+SVN_DUMP="${SVN_DUMP:-$(pwd)/svn.dmp}"
+
+# Name for the svn repository
+SVN_REPO="${SVN_REPO:-$(pwd)/svn-repo}"
+
+# Name for the svn working copy, if any
+SVN_WC="${SVN_WC:-$(pwd)/svn-wc}"
+
+# Name for the migrated git repository
+GIT_REPO="${GIT_REPO:-$(pwd)/git-repo}"
+
+# Name for the migrated git working copy
+GIT_WC="${GIT_WC:-$(pwd)/git-wc}"
+
+# If there is a "test.cond" file present, source it for the "test_cond" fn
+test_cond() { return :; }  # : evaluates to true
+if [ -f "./test.cond" ]; then . ./test.cond; fi
+
+
+##############################################################################
+# Helpers
+
+# Consistent reporting of status messages
+MESSAGE_STATUS () {
+  echo "-- $*"
+}
+
+# Cross between cmake MESSAGE(FATAL) and perl's die
+MESSAGE_FATAL() {
+  echo >&2 "ERROR: $*"
+  exit 1
+}
+
+# Describe test conditions to the user
+TEST_CONDITION() {
+  echo "== TEST: $*"
+}
+
+# Conditions passed
+TEST_PASSED() {
+  echo "== Passed!"
+}
+
+# Describe a test fail and increment the failure count.
+failures=0
+TEST_FAIL() {
+  echo "XX FAILED: $*"
+  failures=$((failures + 1))
+}
+
+# Indents text piped to it
+indent_output () {
+  local identity="${1:-Output}"
+  local indent="${2:-| }"
+  echo "${identity}:"
+  sed -e "s/^/${indent}/"
+  echo
+}
+
+# reset the working environment
+cleanup() {
+  rm -rf "${SVN_REPO}" "${SVN_WC}" "${GIT_REPO}" "${GIT_WC}"
+  rm -rf gitlog-* log*
+}
+
+
+##############################################################################
+# Main code
+
+run_test() {
+  # Reset things to the initial state
+  MESSAGE_STATUS "Cleaning up test environment"
+  cleanup
+  if [ ${CLEAN:-0} -gt 0 ]; then return 0; fi
+
+  # Check that SAFE_EXE refers to a valid, executable file
+  [ -x "${SAFE_EXE}" ] || die "Couldn't find SAFE_EXE (${SAFE_EXE})"
+
+  # Initialize the svn repository
+  MESSAGE_STATUS "Creating SVN repos"
+  svnadmin create "${SVN_REPO}" || die "svnadmin init failed"
+
+  # Load the dump file into the repository
+  MESSAGE_STATUS "Populating SVN repos"
+  svnadmin load "${SVN_REPO}" <"${SVN_DUMP}" || die "svnadmin load failed"
+
+  # Perform the migration
+  MESSAGE_STATUS "Performing migration"
+  "${SAFE_EXE}" --identity-map authors.txt --rules rules.conf --add-metadata --empty-dirs --propcheck --svn-ignore --debug-rules "${SVN_REPO}" \
+    || die "${SAFE_EXE} exited non-zero: $?"
+
+  # Check out the git repository
+  MESSAGE_STATUS "Cloning migrated repos"
+  git clone "${GIT_REPO}" "${GIT_WC}" || die "Git clone failed: $?"
+
+  echo
+  MESSAGE_STATUS
+  MESSAGE_STATUS Running test conditions...
+  MESSAGE_STATUS
+  echo
+
+  pushd "${GIT_WC}"
+  test_cond
+  error=$?
+  popd
+  if [ $failures -gt 0 -o $error -ne 0 ]; then
+    MESSAGE_FATAL  "Test failed"
+  else
+    MESSAGE_STATUS "SUCCESS"
+  fi
+}
+
+
+##############################################################################
+# entry: run main
+
+# This is akin to python's "if __name__ == '__main__': main()"
+if $MAIN ; then run_test; fi
+

--- a/tests/gebaehr-directory-replace/rules.conf
+++ b/tests/gebaehr-directory-replace/rules.conf
@@ -1,0 +1,16 @@
+create repository git-repo
+end repository
+
+match /trunk/
+  repository git-repo
+  branch master
+end match
+
+match /branches/([^/]+)/
+  repository git-repo
+  branch \1
+end match
+
+match /branches/
+  action recurse
+end match

--- a/tests/gebaehr-directory-replace/svn.dmp
+++ b/tests/gebaehr-directory-replace/svn.dmp
@@ -1,0 +1,210 @@
+SVN-fs-dump-format-version: 2
+
+UUID: ed233cc6-8626-614d-8866-28837ce1aded
+
+Revision-number: 0
+Prop-content-length: 56
+Content-length: 56
+
+K 8
+svn:date
+V 27
+2018-03-27T13:38:38.935000Z
+PROPS-END
+
+Revision-number: 1
+Prop-content-length: 127
+Content-length: 127
+
+K 10
+svn:author
+V 7
+gebaehr
+K 8
+svn:date
+V 27
+2018-03-27T13:38:41.859085Z
+K 7
+svn:log
+V 25
+Imported folder structure
+PROPS-END
+
+Node-path: branches
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Node-path: tags
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Node-path: trunk
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Revision-number: 2
+Prop-content-length: 149
+Content-length: 149
+
+K 10
+svn:author
+V 7
+gebaehr
+K 8
+svn:date
+V 27
+2018-03-27T13:41:30.393785Z
+K 7
+svn:log
+V 47
+add folder folder_a and file folder_a/file1.txt
+PROPS-END
+
+Node-path: trunk/folder_a
+Node-kind: dir
+Node-action: add
+Prop-content-length: 10
+Content-length: 10
+
+PROPS-END
+
+
+Node-path: trunk/folder_a/file1.txt
+Node-kind: file
+Node-action: add
+Text-content-md5: cfb2a3740155c041d2c3e13ad1d66644
+Text-content-sha1: 54d1baa10332905f39dfc12c8386cf035b1f4da6
+Prop-content-length: 10
+Text-content-length: 15
+Content-length: 25
+
+PROPS-END
+This is file 1.
+
+Revision-number: 3
+Prop-content-length: 123
+Content-length: 123
+
+K 10
+svn:author
+V 7
+gebaehr
+K 8
+svn:date
+V 27
+2018-03-27T13:42:02.741253Z
+K 7
+svn:log
+V 21
+create branch branch1
+PROPS-END
+
+Node-path: branches/branch1
+Node-kind: dir
+Node-action: add
+Node-copyfrom-rev: 2
+Node-copyfrom-path: trunk
+
+
+Revision-number: 4
+Prop-content-length: 163
+Content-length: 163
+
+K 10
+svn:author
+V 7
+gebaehr
+K 8
+svn:date
+V 27
+2018-03-27T13:43:10.872377Z
+K 7
+svn:log
+V 61
+delete file folder_a/file1.txt + add file  folder_a/file2.txt
+PROPS-END
+
+Node-path: trunk/folder_a/file2.txt
+Node-kind: file
+Node-action: add
+Text-content-md5: 500d703f270d4bc034e159480c83d329
+Text-content-sha1: 45b3cee9ee00b3f683e33edcf5442dc6c3a36091
+Prop-content-length: 10
+Text-content-length: 15
+Content-length: 25
+
+PROPS-END
+This is file 2.
+
+Node-path: trunk/folder_a/file1.txt
+Node-action: delete
+
+
+Revision-number: 5
+Prop-content-length: 123
+Content-length: 123
+
+K 10
+svn:author
+V 7
+gebaehr
+K 8
+svn:date
+V 27
+2018-03-27T13:43:37.615224Z
+K 7
+svn:log
+V 21
+create branch branch2
+PROPS-END
+
+Node-path: branches/branch2
+Node-kind: dir
+Node-action: add
+Node-copyfrom-rev: 4
+Node-copyfrom-path: trunk
+
+
+Revision-number: 6
+Prop-content-length: 154
+Content-length: 154
+
+K 10
+svn:author
+V 7
+gebaehr
+K 8
+svn:date
+V 27
+2018-03-27T13:44:49.516102Z
+K 7
+svn:log
+V 52
+replace folder_a of branch1 with folder_a of branch2
+PROPS-END
+
+Node-path: branches/branch1/folder_a
+Node-action: delete
+
+Node-path: branches/branch1/folder_a
+Node-kind: dir
+Node-action: add
+Node-copyfrom-rev: 5
+Node-copyfrom-path: branches/branch2/folder_a
+
+

--- a/tests/gebaehr-directory-replace/test.cond
+++ b/tests/gebaehr-directory-replace/test.cond
@@ -1,0 +1,25 @@
+test_cond() {
+
+  branch="branch1"
+  expect="folder_a/file2.txt"
+  reject="folder_a/file1.txt"
+
+  TEST_CONDITION "'$branch' should contain $expect and not $reject"
+
+  git checkout --track origin/branch1 || {
+    TEST_FAIL "Couldn't check out branch1"
+    return 1
+  }
+
+  # Show the user what's present
+  ls -R | indent_output "${branch} listing (ls -R)"
+
+  if [ -f "${reject}" ]; then
+    TEST_FAIL "$branch:$reject is present when it shouldn't be"
+  fi
+
+  if [ ! -f "${expect}" ]; then
+    TEST_FAIL "$branch:$expect is not present when it should be"
+  fi
+}
+


### PR DESCRIPTION
https://github.com/svn-all-fast-export/svn2git/issues/43

svn2git handles `svn_fs_path_change_kind` replace for a folder like an add. svn treats it as a delete + add so that pre-existing files are removed.

E.g.

```
   R1   A   /trunk/d1/f1.txt
   R2   A   /branches/b1  (from /trunk)
   R3   D  /trunk/d1/f1.txt
        A /trunk/d1/f2.txt
   R4   D /branches/b1/d1
        A /branches/b1/d1 (from /trunk)
```

`R4` is how `svn log` shows an `svn_fs_path_change_replace`. If you checked out the repos, you would only have `f1.txt` in /branches/b1/d1. After an svn2git migration, you have both d1 and d2 in the git repos.

This also adds a "tests" folder with Ge Bae's test-case and a small harness for using it to (a) repro the test case, (b) verify the fix.
