### PR TITLE
Fix Path Replacements

### DIFF
--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -919,6 +919,10 @@ int SvnRevision::exportInternal(const char *key, const svn_fs_path_change2_t *ch
             }
         }
 
+        if (ignoreSet == false) {
+            txn->deleteFile(path);
+        }
+
         // Add GitIgnore for empty directories (if GitIgnore was not set previously)
         if (CommandLineParser::instance()->contains("empty-dirs") && ignoreSet == false) {
             if (addGitIgnore(pool, key, path, fs_root, txn) == EXIT_SUCCESS) {
@@ -926,9 +930,6 @@ int SvnRevision::exportInternal(const char *key, const svn_fs_path_change2_t *ch
             }
         }
 
-        if (ignoreSet == false) {
-            txn->deleteFile(path);
-        }
         recursiveDumpDir(txn, fs, fs_root, key, path, pool, revnum, rule, matchRules, ruledebug);
     }
 

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -923,8 +923,6 @@ int SvnRevision::exportInternal(const char *key, const svn_fs_path_change2_t *ch
         if (CommandLineParser::instance()->contains("empty-dirs") && ignoreSet == false) {
             if (addGitIgnore(pool, key, path, fs_root, txn) == EXIT_SUCCESS) {
                 return EXIT_SUCCESS;
-            } else {
-                ignoreSet = true;
             }
         }
 


### PR DESCRIPTION
Path replacements did not work properly
- if `--empty-dirs` is used, old files were not cleaned out but survived
- if `--svn-ignore` is used and the path_from has svn:ignore, then the target path did not get a `.gitignore` file

This fixes #43 and is an alternative approach to #62 which tries to solve the first point, but at an earlier `--empty-dirs`-independent place.
I think this fix is the better one as it fixes the actually broken `--empty-dirs` implementation.