### PR TITLE
Fix missing .gitignore in empty dirs on dir rename

### DIFF
--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -960,6 +960,10 @@ int SvnRevision::exportInternal(const char *key, const svn_fs_path_change2_t *ch
         }
 
         recursiveDumpDir(txn, fs, fs_root, key, path, pool, revnum, rule, matchRules, ruledebug);
+
+        if (CommandLineParser::instance()->contains("empty-dirs")) {
+            addGitIgnoreOnBranch(pool, key, path, fs_root, txn);
+        }
     }
 
     if (rule.annotate) {


### PR DESCRIPTION
The commandline option --empty-dirs now also has effect when a directory
was moved in svn.

Before there were no .gitignores added for empty dirs in a moved directory tree.