### PR TITLE
Do not dump added directories multiple times if svn-properties or empty-dirs is used

### DIFF
--- a/test/copy-directories.bats
+++ b/test/copy-directories.bats
@@ -1,0 +1,28 @@
+load 'common'
+
+@test 'copying a directory with source not in target repo should dump full directory' {
+    svn mkdir --parents project-a/dir-a
+    touch project-a/dir-a/file-a
+    svn add project-a/dir-a/file-a
+    svn commit -m 'add project-a/dir-a/file-a'
+    svn mkdir --parents project-b
+    svn commit -m 'add project-b'
+    svn cp project-a/dir-a project-b
+    svn commit -m 'copy project-a/dir-a to project-b'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --debug-rules --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /project-b/
+            repository git-repo
+            branch master
+        end match
+
+        match /project-a/
+        end match
+    ")
+
+    assert git -C git-repo show master:dir-a/file-a
+}

--- a/test/empty-dirs.bats
+++ b/test/empty-dirs.bats
@@ -1,0 +1,173 @@
+load 'common'
+
+@test 'empty-dirs parameter should put empty .gitignore files to empty directories' {
+    svn mkdir dir-a
+    svn commit -m 'add dir-a'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --empty-dirs --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    assert git -C git-repo show master:dir-a/.gitignore
+    assert_equal "$(git -C git-repo show master:dir-a/.gitignore)" ''
+}
+
+@test 'empty-dirs parameter should put empty .gitignore files to empty directories (nested)' {
+    svn mkdir project-a
+    cd project-a
+    svn mkdir dir-a
+    svn commit -m 'add dir-a'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --empty-dirs --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /project-a/
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    assert git -C git-repo show master:dir-a/.gitignore
+    assert_equal "$(git -C git-repo show master:dir-a/.gitignore)" ''
+}
+
+@test 'empty-dirs parameter should not put empty .gitignore files to non-empty directories' {
+    svn mkdir dir-a
+    touch dir-a/file-a
+    svn add dir-a/file-a
+    svn commit -m 'add dir-a/file-a'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --empty-dirs --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    refute git -C git-repo show master:dir-a/.gitignore
+}
+
+@test 'empty-dirs parameter should not put empty .gitignore files to non-empty directories (nested)' {
+    svn mkdir project-a
+    cd project-a
+    svn mkdir dir-a
+    touch dir-a/file-a
+    svn add dir-a/file-a
+    svn commit -m 'add dir-a/file-a'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --empty-dirs --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /project-a/
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    refute git -C git-repo show master:dir-a/.gitignore
+}
+
+@test 'empty-dirs parameter should not put empty .gitignore files to directories with generated .gitignore' {
+    svn mkdir dir-a
+    svn propset svn:ignore $'ignore-a\nignore-b' dir-a
+    svn commit -m 'add dir-a with ignores'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --svn-ignore --empty-dirs --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    assert_equal "$(git -C git-repo show master:dir-a/.gitignore)" "$(cat <<-EOF
+			/ignore-a
+			/ignore-b
+		EOF
+    )"
+}
+
+@test 'empty-dirs parameter should not put empty .gitignore files to directories with generated .gitignore (nested)' {
+    svn mkdir project-a
+    cd project-a
+    svn mkdir dir-a
+    svn propset svn:ignore $'ignore-a\nignore-b' dir-a
+    svn commit -m 'add dir-a with ignores'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --svn-ignore --empty-dirs --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /project-a/
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    assert_equal "$(git -C git-repo show master:dir-a/.gitignore)" "$(cat <<-EOF
+			/ignore-a
+			/ignore-b
+		EOF
+    )"
+}
+
+@test 'empty-dirs parameter should not put empty .gitignore files to directories with .gitignore' {
+    svn mkdir dir-a
+    echo ignore-a >dir-a/.gitignore
+    svn add dir-a/.gitignore
+    svn commit -m 'add dir-a/.gitignore'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --empty-dirs --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    assert_equal "$(git -C git-repo show master:dir-a/.gitignore)" 'ignore-a'
+}
+
+@test 'empty-dirs parameter should not put empty .gitignore files to directories with .gitignore (nested)' {
+    svn mkdir project-a
+    cd project-a
+    svn mkdir dir-a
+    echo ignore-a >dir-a/.gitignore
+    svn add dir-a/.gitignore
+    svn commit -m 'add dir-a/.gitignore'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --empty-dirs --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /project-a/
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    assert_equal "$(git -C git-repo show master:dir-a/.gitignore)" 'ignore-a'
+}

--- a/test/svn-ignore.bats
+++ b/test/svn-ignore.bats
@@ -129,3 +129,95 @@ load 'common'
 		EOF
     )"
 }
+
+@test 'svn-ignore parameter should not cause added directories to be dumped multiple times' {
+    svn mkdir dir-a
+    echo content-a >dir-a/file-a
+    svn add dir-a/file-a
+    svn commit -m 'add dir-a/file-a'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --svn-ignore --create-dump --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    assert [ "$(grep -c '^M .* dir-a/file-a$' git-repo.fi)" -eq 1 ]
+}
+
+@test 'svn-ignore parameter should not cause added directories to be dumped multiple times (nested)' {
+    svn mkdir project-a
+    cd project-a
+    svn mkdir dir-a
+    echo content-a >dir-a/file-a
+    svn add dir-a/file-a
+    svn commit -m 'add dir-a/file-a'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --svn-ignore --create-dump --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /project-a/
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    assert [ "$(grep -c '^M .* dir-a/file-a$' git-repo.fi)" -eq 1 ]
+}
+
+@test 'svn-ignore translation should not delete unrelated files' {
+    svn mkdir dir-a
+    echo content-a >dir-a/file-a
+    svn add dir-a/file-a
+    svn commit -m 'add dir-a/file-a'
+    svn update
+    svn propset svn:ignore 'ignore-a' dir-a
+    svn commit -m 'ignore ignore-a on dir-a'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --svn-ignore --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    assert_equal "$(git -C git-repo show master:dir-a/.gitignore)" '/ignore-a'
+    assert git -C git-repo show master:dir-a/file-a
+}
+
+@test 'svn-ignore translation should not delete unrelated files (nested)' {
+    svn mkdir project-a
+    cd project-a
+    svn mkdir dir-a
+    echo content-a >dir-a/file-a
+    svn add dir-a/file-a
+    svn commit -m 'add dir-a/file-a'
+    svn update
+    svn propset svn:ignore 'ignore-a' dir-a
+    svn commit -m 'ignore ignore-a on dir-a'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --svn-ignore --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /project-a/
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    assert_equal "$(git -C git-repo show master:dir-a/.gitignore)" '/ignore-a'
+    assert git -C git-repo show master:dir-a/file-a
+}


### PR DESCRIPTION
Before this PR a directory was recursively dumped if one of the mentioned parameters was used,
in addition to being dumped because the file is listed separately in the change.