### PR TITLE
Fix missing .gitignore in empty dirs on dir rename

### DIFF
--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -930,6 +930,10 @@ int SvnRevision::exportInternal(const char *key, const svn_fs_path_change2_t *ch
 
         if (dumpDirectory) {
             recursiveDumpDir(txn, fs, fs_root, key, path, pool, revnum, rule, matchRules, ruledebug, ignoreSet);
+
+            if (CommandLineParser::instance()->contains("empty-dirs")) {
+                addGitIgnoreOnBranch(pool, key, path, fs_root, txn);
+            }
         }
     }
 

--- a/test/empty-dirs.bats
+++ b/test/empty-dirs.bats
@@ -912,6 +912,54 @@ load 'common'
     assert_equal "$(git -C git-repo show master:dir-b/.gitignore)" ''
 }
 
+@test 'copying a directory with empty sub-dirs should put empty .gitignore files to empty directories with empty-dirs parameter' {
+    svn mkdir --parents dir-a/subdir-a
+    svn commit -m 'add dir-a/subdir-a'
+    svn cp dir-a dir-b
+    svn commit -m 'copy dir-a to dir-b'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --empty-dirs --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    assert git -C git-repo show master:dir-a/subdir-a/.gitignore
+    assert_equal "$(git -C git-repo show master:dir-a/subdir-a/.gitignore)" ''
+    assert git -C git-repo show master:dir-b/subdir-a/.gitignore
+    assert_equal "$(git -C git-repo show master:dir-b/subdir-a/.gitignore)" ''
+}
+
+@test 'copying a directory with empty sub-dirs should put empty .gitignore files to empty directories with empty-dirs parameter (nested)' {
+    svn mkdir project-a
+    cd project-a
+    svn mkdir --parents dir-a/subdir-a
+    svn commit -m 'add dir-a/subdir-a'
+    svn cp dir-a dir-b
+    svn commit -m 'copy dir-a to dir-b'
+
+    cd "$TEST_TEMP_DIR"
+    svn2git "$SVN_REPO" --empty-dirs --rules <(echo "
+        create repository git-repo
+        end repository
+
+        match /project-a/
+            repository git-repo
+            branch master
+        end match
+    ")
+
+    assert git -C git-repo show master:dir-a/subdir-a/.gitignore
+    assert_equal "$(git -C git-repo show master:dir-a/subdir-a/.gitignore)" ''
+    assert git -C git-repo show master:dir-b/subdir-a/.gitignore
+    assert_equal "$(git -C git-repo show master:dir-b/subdir-a/.gitignore)" ''
+}
+
 @test 'branching with svn-branches and empty-dirs parameter should put empty .gitignore files to empty directories' {
     svn mkdir --parents trunk/dir-a
     svn commit -m 'add trunk/dir-a'


### PR DESCRIPTION
This is a rebase of #89 by @mbaschnitzi (thanks) onto latest master and adds tests for the bug / use-case.
This obsoletes #89.