### PR TITLE
Use `pkg-config` to detect svn and apr libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,37 @@ docker run --rm -it -v `pwd`/workdir:/workdir -v /var/lib/svn/project1:/tmp/svn 
 
 Building the tool
 -----------------
-Run `qmake && make`.  You get `./svn-all-fast-export`.
-(Do a checkout of the repo .git' and run qmake and make. You can only build it after having installed libsvn-dev, and naturally Qt. Running the command will give you all the options you can pass to the tool.)
+In general, clone this repo and run `qmake && make`.  You'll get `./svn-all-fast-export`.
 
 You will need to have some packages to compile it. For Ubuntu distros, use this command to install them all:
-`sudo apt-get install build-essential subversion git qtchooser qt5-default libapr1 libapr1-dev libsvn-dev`
+`sudo apt-get install build-essential pkg-config subversion git qtchooser qt5-default libapr1 libapr1-dev libsvn-dev`
 
+### Linux
+
+This example uses `apt-get`. Use the proper commands and packages for your distro.
+
+```
+$ sudo apt-get install build-essential pkg-config subversion git qtchooser qt5-default libapr1 libapr1-dev libsvn-dev liblz4-dev libutf8proc-dev
+$ git clone https://github.com/svn-all-fast-export/svn2git.git
+$ cd svn2git
+$ qmake && make
+$ ./svn-all-fast-export -h
+```
+
+### macOS + Homebrew
+
+Homebrew installs Qt5 and Apache Portable Runtime as `keg-only`. Therefore in order to build, you will need to tweak your environment as below. `brew install subversion` will also install its dependencies (`apr`, `pkg-confg`, etc.)
+
+```
+$ brew install git qt@5 subversion
+$ export PATH=$(brew --prefix)/opt/qt@5/bin:${PATH}
+$ export PKG_CONFIG_PATH=$(brew --prefix)/opt/apr/lib/pkgconfig
+$ qmake && make
+$ ./svn-all-fast-export -h
+```
+
+Tests
+-----
 To run all tests you can simply call the `test.sh` script in the root directory.
 This will run all [Bats](https://github.com/bats-core/bats-core) based tests
 found in `.bats` files in the directory `test`. Running the script will automatically

--- a/src/src.pro
+++ b/src/src.pro
@@ -1,10 +1,20 @@
-if(!defined(SVN_INCLUDE, var)) {
-  SVN_INCLUDE = /usr/include/subversion-1 /usr/local/include/subversion-1
-}
-if(!defined(APR_INCLUDE, var)) {
-  APR_INCLUDE = /usr/include/apr-1.0 /usr/include/apr-1 /usr/local/include/apr-1
-}
+CONFIG += debug
+CONFIG += warn_off
+CONFIG += silent
+
+QT_CONFIG-=no-pkg-config
+CONFIG+=link_pkgconfig
+PKGCONFIG=apr-1 apr-util-1
+PKGCONFIG+=libsvn_fs libsvn_repos libsvn_subr
+
 exists(local-config.pri):include(local-config.pri)
+
+macos {
+  CONFIG -= app_bundle
+  CONFIG += sdk_no_version_check
+  QMAKE_MACOSX_DEPLOYMENT_TARGET=12.0
+  LIBS += -L$$system(brew --prefix)/lib
+}
 
 if(!defined(VERSION, var)) {
   VERSION = $$system(git --no-pager show --pretty=oneline --no-notes | head -1 | cut -b-40)
@@ -14,7 +24,8 @@ VERSTR = '\\"$${VERSION}\\"'  # place quotes around the version string
 DEFINES += VER=\"$${VERSTR}\" # create a VER macro containing the version string
 
 TEMPLATE = app
-TARGET = ../svn-all-fast-export
+TARGET = svn-all-fast-export
+DESTDIR = ../
 
 isEmpty(PREFIX) {
     PREFIX = /usr/local
@@ -26,10 +37,6 @@ target.path = $$BINDIR
 
 DEPENDPATH += .
 QT = core
-
-INCLUDEPATH += . $$SVN_INCLUDE $$APR_INCLUDE
-!isEmpty(SVN_LIBDIR): LIBS += -L$$SVN_LIBDIR
-LIBS += -lsvn_fs-1 -lsvn_repos-1 -lapr-1 -lsvn_subr-1
 
 # Input
 SOURCES += ruleparser.cpp \


### PR DESCRIPTION
Adds Qt's `pkg-config` support to `src/src.pro` for detecting svn and apr libraries. Also includes build examples in the `README` using the existing style.

pros:
 - simpler config. less hard-coded paths.
 - macOS support

cons:
 - ugh. pkg-config. it want's to link all the things. requires additional dev/devel packages (eg liblz4-dev)
 - macOS support assumes Homebrew

Dealing with `pkg-config`'s _need_ to link all the things could be dealt with by using `pkg-config` directly but this would greatly complicate `src/src.pro`.

closes #135 