### PR TITLE
Update to Debian 11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,16 @@
-FROM debian:8.11
+FROM debian:11
 
 RUN apt update && apt install -y \
-    make g++ libapr1-dev libsvn-dev libqt4-dev \
+    make g++ libapr1-dev libsvn-dev qtbase5-dev \
     git subversion \
     && rm -rf /var/lib/apt/lists/* \
     && mkdir /usr/local/svn2git
 
 ADD . /usr/local/svn2git
 
-RUN cd /usr/local/svn2git && qmake && make
+RUN cd /usr/local/svn2git && qmake && make \
+    && ln -st /usr/local/bin /usr/local/svn2git/svn-all-fast-export \
+    && cp /usr/local/bin/svn-all-fast-export /usr/local/bin/svn2git
 
 WORKDIR /workdir
 CMD /usr/local/svn2git/svn-all-fast-export


### PR DESCRIPTION
This adds support for SVN FS format 7 in the docker container.

The current docker image cannot load SVN 1.8 repos:

```bash
svn: E160043: Expected FS format between '1' and '6'; found format '7'
```