### PR TITLE
Update Dockerfile and CI it

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,3 +67,16 @@ jobs:
           set -e
           make INSTALL_ROOT="${PWD}"/ROOT install
           find ROOT | sort
+
+  docker:
+    name: Check Dockerfile
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Git branch'
+        uses: actions/checkout@v3
+        with:
+          submodules: true
+
+      - name: 'Build'
+        run: |-
+          docker build .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,24 @@
-FROM debian:8.11
+FROM ubuntu:22.04
 
-RUN apt update && apt install -y \
-    make g++ libapr1-dev libsvn-dev libqt4-dev \
-    git subversion \
-    && rm -rf /var/lib/apt/lists/* \
-    && mkdir /usr/local/svn2git
+# Change locale to let svn handle international characters
+ENV LC_ALL C.UTF-8
 
+# Install dependencies
+RUN apt-get update && apt-get install --yes --no-install-recommends \
+    build-essential \
+    libapr1-dev \
+    libsvn-dev \
+    qt5-qmake \
+    qtbase5-dev \
+    git \
+    subversion \
+    && rm -rf /var/lib/apt/lists/*
+
+# Build the binary
+RUN mkdir /usr/local/svn2git
 ADD . /usr/local/svn2git
-
 RUN cd /usr/local/svn2git && qmake && make
 
+# Docker interface
 WORKDIR /workdir
 CMD /usr/local/svn2git/svn-all-fast-export


### PR DESCRIPTION
The current Dockerfile is failing `docker build`:

```
W: GPG error: http://deb.debian.org/ jessie-updates InRelease: The following signatures were invalid: KEYEXPIRED 1668891673
W: GPG error: http://deb.debian.org/ jessie Release: The following signatures were invalid: KEYEXPIRED 1668891673
```
https://github.com/TWiStErRob/svn2git/actions/runs/4282343577/jobs/7456498595