### PR TITLE
Support both Qt 5 and Qt 6 at the same time (fixes #163)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,11 +34,23 @@ jobs:
       matrix:
         include:
           - runs-on: ubuntu-24.04
-            qt: qt5-qmake
+            qt_major: 6
+            qt_qmake: qmake6
+            qt_packages: qmake6 qt6-base-dev qt6-5compat-dev
+          - runs-on: ubuntu-24.04
+            qt_major: 5
+            qt_qmake: qmake
+            qt_packages: qt5-qmake qtbase5-dev
           - runs-on: ubuntu-22.04
-            qt: qt5-qmake
+            qt_major: 6
+            qt_qmake: qmake6
+            qt_packages: qmake6 qt6-base-dev libqt6core5compat6-dev
+          - runs-on: ubuntu-22.04
+            qt_major: 5
+            qt_qmake: qmake
+            qt_packages: qt5-qmake qtbase5-dev
 
-    name: Build (Linux, ${{ matrix.runs-on }})
+    name: Build (Linux, ${{ matrix.runs-on }}, Qt ${{ matrix.qt_major }})
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: 'Install build dependencies'
@@ -49,8 +61,7 @@ jobs:
             build-essential \
             libapr1-dev \
             libsvn-dev \
-            ${{ matrix.qt }} \
-            qtbase5-dev \
+            ${{ matrix.qt_packages }} \
             subversion
 
       - name: 'Checkout Git branch'
@@ -59,8 +70,10 @@ jobs:
           submodules: true
 
       - name: 'Configure'
+        env:
+          QMAKE: ${{ matrix.qt_qmake }}
         run: |-
-          qmake
+          ${QMAKE}
 
       - name: 'Build'
         run: |-

--- a/src/CommandLineParser.cpp
+++ b/src/CommandLineParser.cpp
@@ -79,7 +79,7 @@ void CommandLineParser::Private::addDefinitions(const CommandLineOption * option
         QString option = QString::fromLatin1(options[i].specification);
         // options with optional params are written as "--option required[, optional]
         if (option.indexOf(QLatin1Char(',')) >= 0 && ( option.indexOf(QLatin1Char('[')) < 0 || option.indexOf(QLatin1Char(']')) < 0) ) {
-            QStringList optionParts = option.split(QLatin1Char(','), QString::SkipEmptyParts);
+            QStringList optionParts = option.split(QLatin1Char(','), Qt::SkipEmptyParts);
             if (optionParts.count() != 2) {
                 qWarning() << "WARN: option definition '" << option << "' is faulty; only one ',' allowed";
                 continue;
@@ -104,7 +104,7 @@ void CommandLineParser::Private::addDefinitions(const CommandLineOption * option
         if(definition.name.isEmpty())
             continue;
         if (option.indexOf(QLatin1Char(' ')) > 0) {
-            QStringList optionParts = definition.name.split(QLatin1Char(' '), QString::SkipEmptyParts);
+            QStringList optionParts = definition.name.split(QLatin1Char(' '), Qt::SkipEmptyParts);
             definition.name = optionParts[0];
             bool first = true;
             foreach (QString s, optionParts) {
@@ -137,7 +137,7 @@ void CommandLineParser::Private::setArgumentDefinition(const char *defs)
 {
     requiredArguments = 0;
     argumentDefinition = QString::fromLatin1(defs);
-    QStringList optionParts = argumentDefinition.split(QLatin1Char(' '), QString::SkipEmptyParts);
+    QStringList optionParts = argumentDefinition.split(QLatin1Char(' '), Qt::SkipEmptyParts);
     bool inArg = false;
     foreach (QString s, optionParts) {
         s = s.trimmed();

--- a/src/CommandLineParser.cpp
+++ b/src/CommandLineParser.cpp
@@ -335,10 +335,10 @@ void CommandLineParser::usage(const QString &name, const QString &argumentDescri
         cout << " [OPTION]";
     if (! argumentDescription.isEmpty())
         cout << " " << argumentDescription;
-    cout << endl << endl;
+    cout << Qt::endl << Qt::endl;
 
     if (d->definitions.count() > 0)
-        cout << "Options:" << endl;
+        cout << "Options:" << Qt::endl;
     int commandLength = 0;
     foreach (Private::OptionDefinition definition, d->definitions)
         commandLength = qMax(definition.name.length(), commandLength);
@@ -352,7 +352,7 @@ void CommandLineParser::usage(const QString &name, const QString &argumentDescri
         cout << definition.name;
         for (int i = definition.name.length(); i <= commandLength; i++)
             cout << ' ';
-         cout << definition.comment <<endl;
+         cout << definition.comment << Qt::endl;
     }
 }
 

--- a/src/CommandLineParser.cpp
+++ b/src/CommandLineParser.cpp
@@ -327,7 +327,11 @@ CommandLineParser::~CommandLineParser()
 
 void CommandLineParser::usage(const QString &name, const QString &argumentDescription)
 {
+#if QT_VERSION >= 0x060000
+    QTextStream cout(stdout, QIODeviceBase::WriteOnly);
+#else
     QTextStream cout(stdout, QIODevice::WriteOnly);
+#endif
     cout << "Usage: " << d->argumentStrings[0];
     if (! name.isEmpty())
         cout << " " << name;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -184,7 +184,7 @@ int main(int argc, char **argv)
         foreach (QString option, args->undefinedOptions()) {
             if (!first)
                 out << "          : ";
-            out << "unrecognized option or missing argument for; `" << option << "'" << endl;
+            out << "unrecognized option or missing argument for; `" << option << "'" << Qt::endl;
             first = false;
         }
         return 10;

--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -616,7 +616,7 @@ long long FastImportRepository::markFrom(const QString &branchFrom, int branchRe
         return brFrom.marks.last();
     }
 
-    QVector<int>::const_iterator it = qUpperBound(brFrom.commits, branchRevNum);
+    QVector<int>::const_iterator it = std::upper_bound(brFrom.commits.constBegin(), brFrom.commits.constEnd(), branchRevNum);
     if (it == brFrom.commits.begin()) {
         return 0;
     }

--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -737,7 +737,7 @@ Repository::Transaction *FastImportRepository::newTransaction(const QString &bra
                                                               int revnum)
 {
     if (!branchExists(branch)) {
-        qWarning() << "WARN: Transaction:" << branch << "is not a known branch in repository" << name << endl
+        qWarning() << "WARN: Transaction:" << branch << "is not a known branch in repository" << name << Qt::endl
                    << "Going to create it automatically";
     }
 

--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -1161,7 +1161,7 @@ int FastImportRepository::Transaction::commit()
     mark_t i = !!parentmark;        // if parentmark != 0, there's at least one parent
 
     if(log.contains("This commit was manufactured by cvs2svn") && merges.count() > 1) {
-        qSort(merges);
+        std::sort(merges.begin(), merges.end());
         repository->fastImport.write("merge :" + QByteArray::number(merges.last()) + "\n");
         merges.pop_back();
         qWarning() << "WARN: Discarding all but the highest merge point as a workaround for cvs2svn created branch/tag"

--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -1027,7 +1027,7 @@ QIODevice *FastImportRepository::Transaction::addFile(const QString &path, int m
     modifiedFiles.append(" :");
     modifiedFiles.append(QByteArray::number(mark));
     modifiedFiles.append(' ');
-    modifiedFiles.append(repository->prefix + path.toUtf8());
+    modifiedFiles.append(repository->prefix.toUtf8() + path.toUtf8());
     modifiedFiles.append("\n");
 
     // it is returned for being written to, so start the process in any case
@@ -1080,11 +1080,11 @@ bool FastImportRepository::Transaction::commitNote(const QByteArray &noteText, b
     QByteArray s("");
     s.append("commit refs/notes/commits\n");
     s.append("mark :" + QByteArray::number(maxMark) + "\n");
-    s.append("committer " + author + " " + QString::number(datetime) + " +0000" + "\n");
-    s.append("data " + QString::number(message.length()) + "\n");
+    s.append("committer " + author + " " + QByteArray::number(datetime) + " +0000" + "\n");
+    s.append("data " + QByteArray::number(message.length()) + "\n");
     s.append(message + "\n");
     s.append("N inline " + commitRef + "\n");
-    s.append("data " + QString::number(text.length()) + "\n");
+    s.append("data " + QByteArray::number(text.length()) + "\n");
     s.append(text + "\n");
     repository->startFastImport();
     repository->fastImport.write(s);
@@ -1152,7 +1152,7 @@ int FastImportRepository::Transaction::commit()
     s.append("commit " + branchRef + "\n");
     s.append("mark :" + QByteArray::number(mark) + "\n");
     s.append("committer " + author + " " + QString::number(datetime).toUtf8() + " +0000" + "\n");
-    s.append("data " + QString::number(message.length()) + "\n");
+    s.append("data " + QByteArray::number(message.length()) + "\n");
     s.append(message + "\n");
     repository->fastImport.write(s);
 

--- a/src/ruleparser.cpp
+++ b/src/ruleparser.cpp
@@ -156,7 +156,7 @@ void Rules::load(const QString &filename)
         qFatal("Could not read the rules file: %s", qPrintable(filename));
 
     QTextStream s(&file);
-    QStringList lines = s.readAll().split('\n', QString::KeepEmptyParts);
+    QStringList lines = s.readAll().split('\n', Qt::KeepEmptyParts);
 
     QStringList::iterator it;
     for(it = lines.begin(); it != lines.end(); ++it) {

--- a/src/ruleparser.h
+++ b/src/ruleparser.h
@@ -63,7 +63,11 @@ public:
             QString replacement;
 
             bool isValid() { return !pattern.isEmpty(); }
+#if QT_VERSION >= 0x060000
+            QString apply(QString &string) { return pattern.replaceIn(string, replacement); }
+#else
             QString& apply(QString &string) { return string.replace(pattern, replacement); }
+#endif
         };
 
         QRegExp rx;

--- a/src/src.pro
+++ b/src/src.pro
@@ -29,6 +29,12 @@ target.path = $$BINDIR
 DEPENDPATH += .
 QT = core
 
+_MIN_QT_VERSION = 5.14.0
+
+!versionAtLeast(QT_VERSION, $${_MIN_QT_VERSION}) {
+    error("Qt $${QT_VERSION} found but Qt >=$${_MIN_QT_VERSION} required, cannot continue.")
+}
+
 greaterThan(QT_MAJOR_VERSION, 5) {
     QT += core5compat
 }

--- a/src/src.pro
+++ b/src/src.pro
@@ -29,6 +29,10 @@ target.path = $$BINDIR
 DEPENDPATH += .
 QT = core
 
+greaterThan(QT_MAJOR_VERSION, 5) {
+    QT += core5compat
+}
+
 INCLUDEPATH += . $$SVN_INCLUDE $$APR_INCLUDE
 !isEmpty(SVN_LIBDIR): LIBS += -L$$SVN_LIBDIR
 LIBS += -lsvn_fs-1 -lsvn_repos-1 -lapr-1 -lsvn_subr-1

--- a/src/src.pro
+++ b/src/src.pro
@@ -10,6 +10,8 @@ if(!defined(VERSION, var)) {
   VERSION = $$system(git --no-pager show --pretty=oneline --no-notes | head -1 | cut -b-40)
 }
 
+DEFINES += QT_DISABLE_DEPRECATED_UP_TO=0x05FFFF
+
 VERSTR = '\\"$${VERSION}\\"'  # place quotes around the version string
 DEFINES += VER=\"$${VERSTR}\" # create a VER macro containing the version string
 

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -438,7 +438,11 @@ void SvnRevision::splitPathName(const Rules::Match &rule, const QString &pathNam
 
     if (repository_p) {
         *repository_p = svnprefix;
+#if QT_VERSION >= 0x060000
+        *repository_p = rule.rx.replaceIn(*repository_p, rule.repository);
+#else
         repository_p->replace(rule.rx, rule.repository);
+#endif
         foreach (Rules::Match::Substitution subst, rule.repo_substs) {
             subst.apply(*repository_p);
         }
@@ -446,7 +450,11 @@ void SvnRevision::splitPathName(const Rules::Match &rule, const QString &pathNam
 
     if (effectiveRepository_p) {
         *effectiveRepository_p = svnprefix;
+#if QT_VERSION >= 0x060000
+        *effectiveRepository_p = rule.rx.replaceIn(*effectiveRepository_p, rule.repository);
+#else
         effectiveRepository_p->replace(rule.rx, rule.repository);
+#endif
         foreach (Rules::Match::Substitution subst, rule.repo_substs) {
             subst.apply(*effectiveRepository_p);
         }
@@ -458,7 +466,11 @@ void SvnRevision::splitPathName(const Rules::Match &rule, const QString &pathNam
 
     if (branch_p) {
         *branch_p = svnprefix;
+#if QT_VERSION >= 0x060000
+        *branch_p = rule.rx.replaceIn(*branch_p, rule.branch);
+#else
         branch_p->replace(rule.rx, rule.branch);
+#endif
         foreach (Rules::Match::Substitution subst, rule.branch_substs) {
             subst.apply(*branch_p);
         }
@@ -466,7 +478,11 @@ void SvnRevision::splitPathName(const Rules::Match &rule, const QString &pathNam
 
     if (path_p) {
         QString prefix = svnprefix;
+#if QT_VERSION >= 0x060000
+        prefix = rule.rx.replaceIn(prefix, rule.prefix);
+#else
         prefix.replace(rule.rx, rule.prefix);
+#endif
         *path_p = prefix + pathName.mid(svnprefix.length());
     }
 }
@@ -1308,7 +1324,11 @@ int SvnRevision::fetchIgnoreProps(QString *ignore, apr_pool_t *pool, const char 
         // they didn't match anything in Subversion but would in Git eventually
         ignore->remove(QRegExp("^[^\\r\\n]*[\\\\/][^\\r\\n]*(?:[\\r\\n]|$)|[\\r\\n][^\\r\\n]*[\\\\/][^\\r\\n]*(?=[\\r\\n]|$)"));
         // add a slash in front to have the same meaning in Git of only working on the direct children
+#if QT_VERSION >= 0x060000
+        *ignore = QRegExp("(^|[\\r\\n])\\s*(?![\\r\\n]|$)").replaceIn(*ignore, "\\1/");
+#else
         ignore->replace(QRegExp("(^|[\\r\\n])\\s*(?![\\r\\n]|$)"), "\\1/");
+#endif
         if (ignore->trimmed().isEmpty()) {
             *ignore = QString();
         }
@@ -1330,7 +1350,11 @@ int SvnRevision::fetchIgnoreProps(QString *ignore, apr_pool_t *pool, const char 
     }
 
     // replace multiple asterisks Subversion meaning by Git meaning
+#if QT_VERSION >= 0x060000
+    *ignore = QRegExp("\\*+").replaceIn(*ignore, "*");
+#else
     ignore->replace(QRegExp("\\*+"), "*");
+#endif
 
     return EXIT_SUCCESS;
 }

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -1322,7 +1322,11 @@ int SvnRevision::fetchIgnoreProps(QString *ignore, apr_pool_t *pool, const char 
         *ignore = QString(prop->data);
         // remove patterns with slashes or backslashes,
         // they didn't match anything in Subversion but would in Git eventually
+#if QT_VERSION >= 0x060000
+        *ignore = QRegExp("^[^\\r\\n]*[\\\\/][^\\r\\n]*(?:[\\r\\n]|$)|[\\r\\n][^\\r\\n]*[\\\\/][^\\r\\n]*(?=[\\r\\n]|$)").removeIn(*ignore);
+#else
         ignore->remove(QRegExp("^[^\\r\\n]*[\\\\/][^\\r\\n]*(?:[\\r\\n]|$)|[\\r\\n][^\\r\\n]*[\\\\/][^\\r\\n]*(?=[\\r\\n]|$)"));
+#endif
         // add a slash in front to have the same meaning in Git of only working on the direct children
 #if QT_VERSION >= 0x060000
         *ignore = QRegExp("(^|[\\r\\n])\\s*(?![\\r\\n]|$)").replaceIn(*ignore, "\\1/");
@@ -1343,7 +1347,11 @@ int SvnRevision::fetchIgnoreProps(QString *ignore, apr_pool_t *pool, const char 
         QString global_ignore = QString(prop->data);
         // remove patterns with slashes or backslashes,
         // they didn't match anything in Subversion but would in Git eventually
+#if QT_VERSION >= 0x060000
+        global_ignore = QRegExp("^[^\\r\\n]*[\\\\/][^\\r\\n]*(?:[\\r\\n]|$)|[\\r\\n][^\\r\\n]*[\\\\/][^\\r\\n]*(?=[\\r\\n]|$)").removeIn(global_ignore);
+#else
         global_ignore.remove(QRegExp("^[^\\r\\n]*[\\\\/][^\\r\\n]*(?:[\\r\\n]|$)|[\\r\\n][^\\r\\n]*[\\\\/][^\\r\\n]*(?=[\\r\\n]|$)"));
+#endif
         if (!global_ignore.trimmed().isEmpty()) {
             ignore->append(global_ignore);
         }

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -493,7 +493,11 @@ int SvnRevision::prepareTransactions()
     apr_hash_t *changes;
     SVN_ERR(svn_fs_paths_changed2(&changes, fs_root, pool));
 
+#if QT_VERSION >= 0x060000
+    QMultiMap<QByteArray, svn_fs_path_change2_t*> map;
+#else
     QMap<QByteArray, svn_fs_path_change2_t*> map;
+#endif
     for (apr_hash_index_t *i = apr_hash_first(pool, changes); i; i = apr_hash_next(i)) {
         const void *vkey;
         void *value;
@@ -513,10 +517,18 @@ int SvnRevision::prepareTransactions()
             fflush(stderr);
             exit(1);
         }
+#if QT_VERSION >= 0x060000
+        map.insert(QByteArray(key), change);
+#else
         map.insertMulti(QByteArray(key), change);
+#endif
     }
 
+#if QT_VERSION >= 0x060000
+    QMultiMapIterator<QByteArray, svn_fs_path_change2_t*> i(map);
+#else
     QMapIterator<QByteArray, svn_fs_path_change2_t*> i(map);
+#endif
     while (i.hasNext()) {
         i.next();
         if (exportEntry(i.key(), i.value(), changes) == EXIT_FAILURE)
@@ -991,16 +1003,28 @@ int SvnRevision::recursiveDumpDir(Repository::Transaction *txn, svn_fs_t *fs, sv
 
     // While we get a hash, put it in a map for sorted lookup, so we can
     // repeat the conversions and get the same git commit hashes.
+#if QT_VERSION >= 0x060000
+    QMultiMap<QByteArray, svn_node_kind_t> map;
+#else
     QMap<QByteArray, svn_node_kind_t> map;
+#endif
     for (apr_hash_index_t *i = apr_hash_first(pool, entries); i; i = apr_hash_next(i)) {
         const void *vkey;
         void *value;
         apr_hash_this(i, &vkey, NULL, &value);
         svn_fs_dirent_t *dirent = reinterpret_cast<svn_fs_dirent_t *>(value);
+#if QT_VERSION >= 0x060000
+        map.insert(QByteArray(dirent->name), dirent->kind);
+#else
         map.insertMulti(QByteArray(dirent->name), dirent->kind);
+#endif
     }
 
+#if QT_VERSION >= 0x060000
+    QMultiMapIterator<QByteArray, svn_node_kind_t> i(map);
+#else
     QMapIterator<QByteArray, svn_node_kind_t> i(map);
+#endif
     while (i.hasNext()) {
         dirpool.clear();
         i.next();
@@ -1059,17 +1083,29 @@ int SvnRevision::recurse(const char *path, const svn_fs_path_change2_t *change,
 
     // While we get a hash, put it in a map for sorted lookup, so we can
     // repeat the conversions and get the same git commit hashes.
+#if QT_VERSION >= 0x060000
+    QMultiMap<QByteArray, svn_node_kind_t> map;
+#else
     QMap<QByteArray, svn_node_kind_t> map;
+#endif
     for (apr_hash_index_t *i = apr_hash_first(pool, entries); i; i = apr_hash_next(i)) {
         dirpool.clear();
         const void *vkey;
         void *value;
         apr_hash_this(i, &vkey, NULL, &value);
         svn_fs_dirent_t *dirent = reinterpret_cast<svn_fs_dirent_t *>(value);
+#if QT_VERSION >= 0x060000
+        map.insert(QByteArray(dirent->name), dirent->kind);
+#else
         map.insertMulti(QByteArray(dirent->name), dirent->kind);
+#endif
     }
 
+#if QT_VERSION >= 0x060000
+    QMultiMapIterator<QByteArray, svn_node_kind_t> i(map);
+#else
     QMapIterator<QByteArray, svn_node_kind_t> i(map);
+#endif
     while (i.hasNext()) {
         dirpool.clear();
         i.next();
@@ -1287,16 +1323,28 @@ int SvnRevision::addGitIgnoreOnBranch(apr_pool_t *pool, QString key, QString pat
         return EXIT_FAILURE;
     }
 
+#if QT_VERSION >= 0x060000
+    QMultiMap<QByteArray, svn_node_kind_t> map;
+#else
     QMap<QByteArray, svn_node_kind_t> map;
+#endif
     for (apr_hash_index_t *i = apr_hash_first(pool, entries); i; i = apr_hash_next(i)) {
         const void *vkey;
         void *value;
         apr_hash_this(i, &vkey, NULL, &value);
         svn_fs_dirent_t *dirent = reinterpret_cast<svn_fs_dirent_t *>(value);
+#if QT_VERSION >= 0x060000
+        map.insert(QByteArray(dirent->name), dirent->kind);
+#else
         map.insertMulti(QByteArray(dirent->name), dirent->kind);
+#endif
     }
 
+#if QT_VERSION >= 0x060000
+    QMultiMapIterator<QByteArray, svn_node_kind_t> i(map);
+#else
     QMapIterator<QByteArray, svn_node_kind_t> i(map);
+#endif
     while (i.hasNext()) {
         i.next();
         QString entryName = key + "/" + i.key();


### PR DESCRIPTION
Fixes #163

Please note that:
- I have not migrated off of class `QRegExp` because successor `QRegularExpression` has a different pattern syntax and so backwards compatibility would be broken e.g. with regard to existing rules files. That migration should probably be a distinct future pull request and come with a bump in major version to signal its breaking nature.
- While I have applied care here, true C++ is not my day-to-day language so this should be reviewed carefully before merging. Thanks in advance!
- If this gets merged, please do not squash-merge but preserve the commit cut lines that have been chosen carefully. Thank you!
