### PR TITLE
Fix warnings

### DIFF
--- a/src/CommandLineParser.cpp
+++ b/src/CommandLineParser.cpp
@@ -184,7 +184,7 @@ void CommandLineParser::Private::parse()
                 else if (!clp->undefinedOptions.contains(option.option))
                     clp->undefinedOptions << option.option;
                 else
-                    clp->errors.append(QLatin1String("Not enough arguments passed for option `")
+                    clp->errors.append(QStringLiteral("Not enough arguments passed for option `")
                             + option.option +QLatin1Char('\''));
             }
             option.option.clear();
@@ -260,7 +260,7 @@ void CommandLineParser::Private::parse()
     processor.next(option);
 
     if (requiredArguments > arguments.count())
-        errors.append(QLatin1String("Not enough arguments, usage: ") + QString::fromLocal8Bit(argumentStrings[0])
+        errors.append(QStringLiteral("Not enough arguments, usage: ") + QString::fromLocal8Bit(argumentStrings[0])
                 + QLatin1Char(' ') + argumentDefinition);
 
 /*
@@ -367,6 +367,12 @@ QStringList CommandLineParser::options() const
 }
 
 bool CommandLineParser::contains(const QString & key) const
+{
+    d->parse();
+    return d->options.contains(key);
+}
+
+bool CommandLineParser::contains(const QLatin1String & key) const
 {
     d->parse();
     return d->options.contains(key);

--- a/src/CommandLineParser.h
+++ b/src/CommandLineParser.h
@@ -72,6 +72,14 @@ public:
      */
     bool contains(const QString & key) const;
 
+    /**
+     * returns true if the option was found.
+     * Consider the following definition "--expert level"  The user can type as an argument
+     * "--expert 10".  Calling contains("expert") will return true.
+     * @see optionArgument()
+     */
+    bool contains(const QLatin1String & key) const;
+
     /// returns the list of items that are not options, note that the first one is the name of the command called
     QStringList arguments() const;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -110,7 +110,7 @@ QSet<int> loadRevisionsFile( const QString &fileName, Svn &svn )
                 continue;
             }
             int lastrev = 0;
-            if(revint.cap(2) == "HEAD") {
+            if(revint.cap(2) == QLatin1String("HEAD")) {
                 lastrev = svn.youngestRevision();
                 ok = true;
             } else {
@@ -170,11 +170,11 @@ int main(int argc, char **argv)
         return 0;
     }
     if (args->contains(QLatin1String("help"))) {
-        args->usage(QString(), "--rules RULES_FILE SVN_REPO_DIR/");
+        args->usage(QString(), QStringLiteral("--rules RULES_FILE SVN_REPO_DIR/"));
         return 0;
     }
     if (args->arguments().count() != 1) {
-        args->usage(QString(), "--rules RULES_FILE SVN_REPO_DIR/");
+        args->usage(QString(), QStringLiteral("--rules RULES_FILE SVN_REPO_DIR/"));
         return 12;
     }
     if (args->undefinedOptions().count()) {
@@ -189,23 +189,23 @@ int main(int argc, char **argv)
         }
         return 10;
     }
-    if (!args->contains("rules")) {
+    if (!args->contains(QLatin1String("rules"))) {
         QTextStream out(stderr);
         out << "svn-all-fast-export failed: please specify the rules using the 'rules' argument\n";
         return 11;
     }
-    if (!args->contains("identity-map") && !args->contains("identity-domain")) {
+    if (!args->contains(QLatin1String("identity-map")) && !args->contains(QLatin1String("identity-domain"))) {
         QTextStream out(stderr);
         out << "WARNING; no identity-map or -domain specified, all commits will use default @localhost email address\n\n";
     }
 
     QCoreApplication app(argc, argv);
     // Load the configuration
-    RulesList rulesList(args->optionArgument(QLatin1String("rules")));
+    RulesList rulesList(args->optionArgument(QStringLiteral("rules")));
     rulesList.load();
 
-    int resume_from = args->optionArgument(QLatin1String("resume-from")).toInt();
-    int max_rev = args->optionArgument(QLatin1String("max-rev")).toInt();
+    int resume_from = args->optionArgument(QStringLiteral("resume-from")).toInt();
+    int max_rev = args->optionArgument(QStringLiteral("max-rev")).toInt();
 
     // create the repository list
     QHash<QString, Repository *> repositories;
@@ -263,9 +263,9 @@ int main(int argc, char **argv)
     Svn svn(args->arguments().constFirst());
     svn.setMatchRules(rulesList.allMatchRules());
     svn.setRepositories(repositories);
-    svn.setIdentityMap(loadIdentityMapFile(args->optionArgument("identity-map")));
+    svn.setIdentityMap(loadIdentityMapFile(args->optionArgument(QStringLiteral("identity-map"))));
     // Massage user input a little, no guarantees that input makes sense.
-    QString domain = args->optionArgument("identity-domain").simplified().remove(QChar('@'));
+    QString domain = args->optionArgument(QStringLiteral("identity-domain")).simplified().remove(QChar('@'));
     if (domain.isEmpty())
         domain = QString("localhost");
     svn.setIdentityDomain(domain);
@@ -274,7 +274,7 @@ int main(int argc, char **argv)
         max_rev = svn.youngestRevision();
 
     bool errors = false;
-    QSet<int> revisions = loadRevisionsFile(args->optionArgument(QLatin1String("revisions-file")), svn);
+    QSet<int> revisions = loadRevisionsFile(args->optionArgument(QStringLiteral("revisions-file")), svn);
     const bool filerRevisions = !revisions.isEmpty();
     for (int i = min_rev; i <= max_rev; ++i) {
         if(filerRevisions) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -260,7 +260,7 @@ int main(int argc, char **argv)
         min_rev = resume_from;
 
     Svn::initialize();
-    Svn svn(args->arguments().first());
+    Svn svn(args->arguments().constFirst());
     svn.setMatchRules(rulesList.allMatchRules());
     svn.setRepositories(repositories);
     svn.setIdentityMap(loadIdentityMapFile(args->optionArgument("identity-map")));

--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -618,7 +618,7 @@ long long FastImportRepository::markFrom(const QString &branchFrom, int branchRe
     }
 
     QVector<int>::const_iterator it = std::upper_bound(brFrom.commits.constBegin(), brFrom.commits.constEnd(), branchRevNum);
-    if (it == brFrom.commits.begin()) {
+    if (it == brFrom.commits.constBegin()) {
         return 0;
     }
 

--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -575,8 +575,9 @@ void FastImportRepository::closeFastImport()
 void FastImportRepository::reloadBranches()
 {
     bool reset_notes = false;
-    foreach (QString branch, branches.keys()) {
-        Branch &br = branches[branch];
+    for (auto it = branches.keyValueBegin(); it != branches.keyValueEnd(); ++it) {
+        const QString &branch = it->first;
+        Branch &br = it->second;
 
         if (br.marks.isEmpty() || !br.marks.last())
             continue;
@@ -1099,8 +1100,9 @@ bool FastImportRepository::Transaction::commitNote(const QByteArray &noteText, b
 
 int FastImportRepository::Transaction::commit()
 {
-    foreach (QString branchName, repository->branches.keys())
+    for (auto it = repository->branches.keyValueBegin(); it != repository->branches.keyValueEnd(); ++it)
     {
+        const QString &branchName = it->first;
         if (branchName.toUtf8().startsWith(branch + "/") || branch.startsWith((branchName + "/").toUtf8()))
         {
             qCritical() << "Branch" << branch << "conflicts with already existing branch" << branchName;

--- a/src/repository.cpp
+++ b/src/repository.cpp
@@ -329,7 +329,7 @@ FastImportRepository::FastImportRepository(const Rules::Repository &rule)
 
     // create the defaultBranch from the config
     QProcess config;
-    config.start("git", QStringList() << "config" << "init.defaultBranch");
+    config.start(QStringLiteral("git"), QStringList() << QStringLiteral("config") << QStringLiteral("init.defaultBranch"));
     config.waitForFinished(-1);
     defaultBranch = QString(config.readAllStandardOutput()).trimmed();
 
@@ -340,22 +340,22 @@ FastImportRepository::FastImportRepository(const Rules::Repository &rule)
 
     branches[defaultBranch].created = 1;
 
-    if (!CommandLineParser::instance()->contains("dry-run") && !CommandLineParser::instance()->contains("create-dump")) {
+    if (!CommandLineParser::instance()->contains(QStringLiteral("dry-run")) && !CommandLineParser::instance()->contains(QStringLiteral("create-dump"))) {
         fastImport.setWorkingDirectory(name);
         if (!QDir(name).exists()) { // repo doesn't exist yet.
             qDebug() << "Creating new repository" << name;
             QDir::current().mkpath(name);
             QProcess init;
             init.setWorkingDirectory(name);
-            init.start("git", QStringList() << "--bare" << "init");
+            init.start(QStringLiteral("git"), QStringList() << QStringLiteral("--bare") << QStringLiteral("init"));
             init.waitForFinished(-1);
             QProcess casesensitive;
             casesensitive.setWorkingDirectory(name);
-            casesensitive.start("git", QStringList() << "config" << "core.ignorecase" << "false");
+            casesensitive.start(QStringLiteral("git"), QStringList() << QStringLiteral("config") << QStringLiteral("core.ignorecase") << QStringLiteral("false"));
             casesensitive.waitForFinished(-1);
             // Write description
             if (!rule.description.isEmpty()) {
-                QFile fDesc(QDir(name).filePath("description"));
+                QFile fDesc(QDir(name).filePath(QStringLiteral("description")));
                 if (fDesc.open(QIODevice::WriteOnly | QIODevice::Truncate | QIODevice::Text)) {
                             fDesc.write(rule.description.toUtf8());
                     fDesc.putChar('\n');
@@ -374,7 +374,7 @@ FastImportRepository::FastImportRepository(const Rules::Repository &rule)
 static QString logFileName(QString name)
 {
     name.replace('/', '_');
-    if (CommandLineParser::instance()->contains("create-dump"))
+    if (CommandLineParser::instance()->contains(QStringLiteral("create-dump")))
         name.append(".fi");
     else
         name.prepend("log-");
@@ -551,7 +551,7 @@ FastImportRepository::~FastImportRepository()
 void FastImportRepository::closeFastImport()
 {
     if (fastImport.state() != QProcess::NotRunning) {
-        int fastImportTimeout = CommandLineParser::instance()->optionArgument(QLatin1String("fast-import-timeout"), QLatin1String("30")).toInt();
+        int fastImportTimeout = CommandLineParser::instance()->optionArgument(QStringLiteral("fast-import-timeout"), QStringLiteral("30")).toInt();
         if(fastImportTimeout == 0) {
             qDebug() << "Waiting forever for fast-import to finish.";
             fastImportTimeout = -1;
@@ -595,7 +595,7 @@ void FastImportRepository::reloadBranches()
     }
 
     if (reset_notes &&
-        CommandLineParser::instance()->contains("add-metadata-notes")) {
+        CommandLineParser::instance()->contains(QStringLiteral("add-metadata-notes"))) {
 
         startFastImport();
         fastImport.write("reset refs/notes/commits\nfrom :" +
@@ -724,7 +724,7 @@ void FastImportRepository::commit()
         QString tagName = *it;
         if (resetBranchNames.contains(tagName))
             continue;
-        if (tagName.startsWith("refs/tags/"))
+        if (tagName.startsWith(QLatin1String("refs/tags/")))
             tagName.remove(0, 10);
         if (annotatedTags.remove(tagName) > 0) {
             qDebug() << "Removing annotated tag" << tagName << "for" << name;
@@ -749,7 +749,7 @@ Repository::Transaction *FastImportRepository::newTransaction(const QString &bra
     txn->datetime = 0;
     txn->revnum = revnum;
 
-    if ((++commitCount % CommandLineParser::instance()->optionArgument(QLatin1String("commit-interval"), QLatin1String("10000")).toInt()) == 0) {
+    if ((++commitCount % CommandLineParser::instance()->optionArgument(QStringLiteral("commit-interval"), QStringLiteral("10000")).toInt()) == 0) {
         startFastImport();
         // write everything to disk every 10000 commits
         fastImport.write("checkpoint\n");
@@ -771,7 +771,7 @@ void FastImportRepository::createAnnotatedTag(const QString &ref, const QString 
                                               const QByteArray &log)
 {
     QString tagName = ref;
-    if (tagName.startsWith("refs/tags/"))
+    if (tagName.startsWith(QLatin1String("refs/tags/")))
         tagName.remove(0, 10);
 
     if (!annotatedTags.contains(tagName))
@@ -810,7 +810,7 @@ void FastImportRepository::finalizeTags()
         QByteArray message = tag.log;
         if (!message.endsWith('\n'))
             message += '\n';
-        if (CommandLineParser::instance()->contains("add-metadata"))
+        if (CommandLineParser::instance()->contains(QStringLiteral("add-metadata")))
             message += "\n" + formatMetadataMessage(tag.svnprefix, tag.revnum, tagName.toUtf8());
 
         {
@@ -833,7 +833,7 @@ void FastImportRepository::finalizeTags()
 
         // Append note to the tip commit of the supporting ref. There is no
         // easy way to attach a note to the tag itself with fast-import.
-        if (CommandLineParser::instance()->contains("add-metadata-notes")) {
+        if (CommandLineParser::instance()->contains(QStringLiteral("add-metadata-notes"))) {
             Repository::Transaction *txn = newTransaction(tag.supportingRef, tag.svnprefix, tag.revnum);
             txn->setAuthor(tag.author);
             txn->setDateTime(tag.dt);
@@ -859,7 +859,7 @@ void FastImportRepository::saveBranchNotes()
     if (branchNotes.isEmpty())
         return;
 
-    QFile branchNotesFile(name + "/" + branchNotesFileName(name));
+    QFile branchNotesFile(name + QStringLiteral("/") + branchNotesFileName(name));
     branchNotesFile.open(QIODevice::WriteOnly);
     QDataStream branchNotesStream(&branchNotesFile);
     branchNotesStream << branchNotes;
@@ -875,7 +875,7 @@ FastImportRepository::msgFilter(QByteArray msg)
         if (filterMsg.state() == QProcess::Running)
             qFatal("filter process already running?");
 
-        filterMsg.start(CommandLineParser::instance()->optionArgument("msg-filter"));
+        filterMsg.start(CommandLineParser::instance()->optionArgument(QStringLiteral("msg-filter")));
 
         if(!(filterMsg.waitForStarted(-1)))
             qFatal("Failed to Start Filter %d %s", __LINE__, qPrintable(filterMsg.errorString()));
@@ -900,17 +900,17 @@ void FastImportRepository::startFastImport()
         // start the process
         QString marksFile = marksFileName(name);
         QStringList marksOptions;
-        marksOptions << "--import-marks=" + marksFile;
-        marksOptions << "--export-marks=" + marksFile;
-        marksOptions << "--force";
+        marksOptions << QStringLiteral("--import-marks=") + marksFile;
+        marksOptions << QStringLiteral("--export-marks=") + marksFile;
+        marksOptions << QStringLiteral("--force");
 
         fastImport.setStandardOutputFile(logFileName(name), QIODevice::Append);
         fastImport.setProcessChannelMode(QProcess::MergedChannels);
 
-        if (!CommandLineParser::instance()->contains("dry-run") && !CommandLineParser::instance()->contains("create-dump")) {
-            fastImport.start("git", QStringList() << "fast-import" << marksOptions);
+        if (!CommandLineParser::instance()->contains(QStringLiteral("dry-run")) && !CommandLineParser::instance()->contains(QStringLiteral("create-dump"))) {
+            fastImport.start(QStringLiteral("git"), QStringList() << QStringLiteral("fast-import") << marksOptions);
         } else {
-            fastImport.start("cat", QStringList());
+            fastImport.start(QStringLiteral("cat"), QStringList());
         }
         fastImport.waitForStarted(-1);
 
@@ -1033,7 +1033,7 @@ QIODevice *FastImportRepository::Transaction::addFile(const QString &path, int m
 
     // it is returned for being written to, so start the process in any case
     repository->startFastImport();
-    if (!CommandLineParser::instance()->contains("dry-run")) {
+    if (!CommandLineParser::instance()->contains(QStringLiteral("dry-run"))) {
         repository->fastImport.writeNoLog("blob\nmark :");
         repository->fastImport.writeNoLog(QByteArray::number(mark));
         repository->fastImport.writeNoLog("\ndata ");
@@ -1124,7 +1124,7 @@ int FastImportRepository::Transaction::commit()
     QByteArray message = log;
     if (!message.endsWith('\n'))
         message += '\n';
-    if (CommandLineParser::instance()->contains("add-metadata"))
+    if (CommandLineParser::instance()->contains(QStringLiteral("add-metadata")))
         message += "\n" + Repository::formatMetadataMessage(svnprefix, revnum);
 
     // Call external message filter if provided
@@ -1192,7 +1192,7 @@ int FastImportRepository::Transaction::commit()
         }
     }
     // write the file deletions
-    if (deletedFiles.contains(""))
+    if (deletedFiles.contains(QLatin1String("")))
         repository->fastImport.write("deleteall\n");
     else
         foreach (QString df, deletedFiles)
@@ -1210,7 +1210,7 @@ int FastImportRepository::Transaction::commit()
            qPrintable(repository->name), branch.data());
 
     // Commit metadata note if requested
-    if (CommandLineParser::instance()->contains("add-metadata-notes"))
+    if (CommandLineParser::instance()->contains(QStringLiteral("add-metadata-notes")))
         commitNote(Repository::formatMetadataMessage(svnprefix, revnum), false);
 
     while (repository->fastImport.bytesToWrite())

--- a/src/repository.h
+++ b/src/repository.h
@@ -32,7 +32,7 @@ class LoggingQProcess : public QProcess
     bool logging;
 public:
     LoggingQProcess(const QString filename) : QProcess(), log() {
-        if(CommandLineParser::instance()->contains("debug-rules")) {
+        if(CommandLineParser::instance()->contains(QStringLiteral("debug-rules"))) {
             logging = true;
             QString name = filename;
             name.replace('/', '_');

--- a/src/ruleparser.cpp
+++ b/src/ruleparser.cpp
@@ -173,7 +173,7 @@ void Rules::load(const QString &filename)
 
         bool isIncludeRule = includeLine.exactMatch(line);
         if (isIncludeRule) {
-            int index = filename.lastIndexOf("/");
+            int index = filename.lastIndexOf('/');
             QString includeFile = filename.left( index + 1) + includeLine.cap(1);
             load(includeFile);
         } else {
@@ -206,7 +206,7 @@ void Rules::load(const QString &filename)
                 } else if (matchPrefixLine.exactMatch(line)) {
                     repo.prefix = matchPrefixLine.cap(1);
                     continue;
-                } else if (line == "end repository") {
+                } else if (line == QLatin1String("end repository")) {
                     if (!repo.forwardTo.isEmpty()
                         && !repo.description.isEmpty()) {
 
@@ -252,7 +252,7 @@ void Rules::load(const QString &filename)
                     match.branch_substs += subst;
                     continue;
                 } else if (matchRevLine.exactMatch(line)) {
-                    if (matchRevLine.cap(1) == "min")
+                    if (matchRevLine.cap(1) == QLatin1String("min"))
                         match.minRevision = matchRevLine.cap(2).toInt();
                     else            // must be max
                         match.maxRevision = matchRevLine.cap(2).toInt();
@@ -264,19 +264,19 @@ void Rules::load(const QString &filename)
                     continue;
                 } else if (matchActionLine.exactMatch(line)) {
                     QString action = matchActionLine.cap(1);
-                    if (action == "export")
+                    if (action == QLatin1String("export"))
                         match.action = Match::Export;
-                    else if (action == "ignore")
+                    else if (action == QLatin1String("ignore"))
                         match.action = Match::Ignore;
-                    else if (action == "recurse")
+                    else if (action == QLatin1String("recurse"))
                         match.action = Match::Recurse;
                     else
                         qFatal("Invalid action \"%s\" on line %d", qPrintable(action), lineNumber);
                     continue;
                 } else if (matchAnnotateLine.exactMatch(line)) {
-                    match.annotate = matchAnnotateLine.cap(1) == "true";
+                    match.annotate = matchAnnotateLine.cap(1) == QLatin1String("true");
                     continue;
-                } else if (line == "end match") {
+                } else if (line == QLatin1String("end match")) {
                     if (!match.repository.isEmpty())
                         match.action = Match::Export;
                     m_matchRules += match;
@@ -336,7 +336,7 @@ private:
 
 Stats::Stats() : d(new Private())
 {
-    use = CommandLineParser::instance()->contains("stats");
+    use = CommandLineParser::instance()->contains(QStringLiteral("stats"));
 }
 
 Stats::~Stats()

--- a/src/ruleparser.cpp
+++ b/src/ruleparser.cpp
@@ -381,8 +381,8 @@ Stats::Private::Private()
 void Stats::Private::printStats() const
 {
     printf("\nRule stats\n");
-    foreach(const Rules::Match rule, m_usedRules.keys()) {
-        printf("%s was matched %i times\n", qPrintable(rule.info()), m_usedRules[rule]);
+    for (auto it = m_usedRules.keyValueBegin(); it != m_usedRules.keyValueEnd(); ++it) {
+        printf("%s was matched %i times\n", qPrintable(it->first.info()), it->second);
     }
 }
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -29,7 +29,7 @@ target.path = $$BINDIR
 DEPENDPATH += .
 QT = core
 
-_MIN_QT_VERSION = 5.14.0
+_MIN_QT_VERSION = 5.15.0
 
 !versionAtLeast(QT_VERSION, $${_MIN_QT_VERSION}) {
     error("Qt $${QT_VERSION} found but Qt >=$${_MIN_QT_VERSION} required, cannot continue.")

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -567,8 +567,8 @@ int SvnRevision::commit()
     // now create the commit
     if (fetchRevProps() != EXIT_SUCCESS)
         return EXIT_FAILURE;
-    foreach (Repository *repo, repositories.values()) {
-        repo->commit();
+    for (auto it = repositories.keyValueBegin(); it != repositories.keyValueEnd(); ++it) {
+        it->second->commit();
     }
 
     foreach (Repository::Transaction *txn, transactions) {

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -517,11 +517,7 @@ int SvnRevision::prepareTransactions()
             fflush(stderr);
             exit(1);
         }
-#if QT_VERSION >= 0x060000
         map.insert(QByteArray(key), change);
-#else
-        map.insertMulti(QByteArray(key), change);
-#endif
     }
 
 #if QT_VERSION >= 0x060000
@@ -1013,11 +1009,7 @@ int SvnRevision::recursiveDumpDir(Repository::Transaction *txn, svn_fs_t *fs, sv
         void *value;
         apr_hash_this(i, &vkey, NULL, &value);
         svn_fs_dirent_t *dirent = reinterpret_cast<svn_fs_dirent_t *>(value);
-#if QT_VERSION >= 0x060000
         map.insert(QByteArray(dirent->name), dirent->kind);
-#else
-        map.insertMulti(QByteArray(dirent->name), dirent->kind);
-#endif
     }
 
 #if QT_VERSION >= 0x060000
@@ -1094,11 +1086,7 @@ int SvnRevision::recurse(const char *path, const svn_fs_path_change2_t *change,
         void *value;
         apr_hash_this(i, &vkey, NULL, &value);
         svn_fs_dirent_t *dirent = reinterpret_cast<svn_fs_dirent_t *>(value);
-#if QT_VERSION >= 0x060000
         map.insert(QByteArray(dirent->name), dirent->kind);
-#else
-        map.insertMulti(QByteArray(dirent->name), dirent->kind);
-#endif
     }
 
 #if QT_VERSION >= 0x060000
@@ -1333,11 +1321,7 @@ int SvnRevision::addGitIgnoreOnBranch(apr_pool_t *pool, QString key, QString pat
         void *value;
         apr_hash_this(i, &vkey, NULL, &value);
         svn_fs_dirent_t *dirent = reinterpret_cast<svn_fs_dirent_t *>(value);
-#if QT_VERSION >= 0x060000
         map.insert(QByteArray(dirent->name), dirent->kind);
-#else
-        map.insertMulti(QByteArray(dirent->name), dirent->kind);
-#endif
     }
 
 #if QT_VERSION >= 0x060000

--- a/src/svn.cpp
+++ b/src/svn.cpp
@@ -264,7 +264,7 @@ static int dumpBlob(Repository::Transaction *txn, svn_fs_root_t *fs_root,
     SVN_ERR(svn_fs_file_length(&stream_length, fs_root, pathname, dumppool));
 
     svn_stream_t *in_stream, *out_stream;
-    if (!CommandLineParser::instance()->contains("dry-run")) {
+    if (!CommandLineParser::instance()->contains(QStringLiteral("dry-run"))) {
         // open the file
         SVN_ERR(svn_fs_file_contents(&in_stream, fs_root, pathname, dumppool));
     }
@@ -274,7 +274,7 @@ static int dumpBlob(Repository::Transaction *txn, svn_fs_root_t *fs_root,
     SVN_ERR(svn_fs_node_prop(&propvalue, fs_root, pathname, "svn:special", dumppool));
     if (propvalue) {
         apr_size_t len = strlen("link ");
-        if (!CommandLineParser::instance()->contains("dry-run")) {
+        if (!CommandLineParser::instance()->contains(QStringLiteral("dry-run"))) {
             QByteArray buf;
             buf.reserve(len);
             SVN_ERR(svn_stream_read_full(in_stream, buf.data(), &len));
@@ -293,7 +293,7 @@ static int dumpBlob(Repository::Transaction *txn, svn_fs_root_t *fs_root,
 
     QIODevice *io = txn->addFile(finalPathName, mode, stream_length);
 
-    if (!CommandLineParser::instance()->contains("dry-run")) {
+    if (!CommandLineParser::instance()->contains(QStringLiteral("dry-run"))) {
         // open a generic svn_stream_t for the QIODevice
         out_stream = streamForDevice(io, dumppool);
         SVN_ERR(svn_stream_copy3(in_stream, out_stream, NULL, NULL, dumppool));
@@ -604,10 +604,10 @@ int SvnRevision::exportEntry(const char *key, const svn_fs_path_change2_t *chang
     SVN_ERR(svn_fs_is_dir(&is_dir, fs_root, key, revpool));
     // Adding newly created directories
     if (is_dir && change->change_kind == svn_fs_path_change_add && path_from == NULL
-        && CommandLineParser::instance()->contains("empty-dirs")) {
+        && CommandLineParser::instance()->contains(QStringLiteral("empty-dirs"))) {
         QString keyQString = key;
         // Skipping SVN-directory-layout
-        if (keyQString.endsWith("/trunk") || keyQString.endsWith("/branches") || keyQString.endsWith("/tags")) {
+        if (keyQString.endsWith(QLatin1String("/trunk")) || keyQString.endsWith(QLatin1String("/branches")) || keyQString.endsWith(QLatin1String("/tags"))) {
             //qDebug() << "Skipping SVN-directory-layout:" << keyQString;
             return EXIT_SUCCESS;
         }
@@ -616,7 +616,7 @@ int SvnRevision::exportEntry(const char *key, const svn_fs_path_change2_t *chang
     }
     // svn:ignore-properties
     else if (is_dir && (change->change_kind == svn_fs_path_change_add || change->change_kind == svn_fs_path_change_modify || change->change_kind == svn_fs_path_change_replace)
-             && path_from == NULL && CommandLineParser::instance()->contains("svn-ignore")) {
+             && path_from == NULL && CommandLineParser::instance()->contains(QStringLiteral("svn-ignore"))) {
         needCommit = true;
     }
     else if (is_dir) {
@@ -813,7 +813,7 @@ int SvnRevision::exportInternal(const char *key, const svn_fs_path_change2_t *ch
                 return EXIT_FAILURE;
             }
 
-            if(CommandLineParser::instance()->contains("empty-dirs")) {
+            if(CommandLineParser::instance()->contains(QStringLiteral("empty-dirs"))) {
                 Repository::Transaction *txn = transactions.value(repository + branch, 0);
                 if (!txn) {
                     txn = repo->newTransaction(branch, svnprefix, revnum);
@@ -847,7 +847,7 @@ int SvnRevision::exportInternal(const char *key, const svn_fs_path_change2_t *ch
                 txn->deleteFile(path);
                 checkParentNotEmpty(pool, key, path, fs_root, txn);
                 recursiveDumpDir(txn, fs, fs_root, key, path, pool, revnum, rule, matchRules, ruledebug, false);
-                if (CommandLineParser::instance()->contains("empty-dirs")) {
+                if (CommandLineParser::instance()->contains(QStringLiteral("empty-dirs"))) {
                     addGitIgnoreOnBranch(pool, key, path, fs_root, txn);
                 }
             }
@@ -903,7 +903,7 @@ int SvnRevision::exportInternal(const char *key, const svn_fs_path_change2_t *ch
 
         // Check unknown svn-properties
         if (((path_from == NULL && change->prop_mod==1) || (path_from != NULL && (change->change_kind == svn_fs_path_change_add || change->change_kind == svn_fs_path_change_replace)))
-            && CommandLineParser::instance()->contains("propcheck")) {
+            && CommandLineParser::instance()->contains(QStringLiteral("propcheck"))) {
             if (fetchUnknownProps(pool, key, fs_root) != EXIT_SUCCESS) {
                 qWarning() << "Error checking svn-properties (" << key << ")";
             }
@@ -931,7 +931,7 @@ int SvnRevision::exportInternal(const char *key, const svn_fs_path_change2_t *ch
         // Add GitIgnore with svn:ignore
         int ignoreSet = false;
         if (((path_from == NULL && change->prop_mod==1) || (path_from != NULL && (change->change_kind == svn_fs_path_change_add || change->change_kind == svn_fs_path_change_replace)))
-            && CommandLineParser::instance()->contains("svn-ignore")) {
+            && CommandLineParser::instance()->contains(QStringLiteral("svn-ignore"))) {
             QString svnignore;
             // TODO: Check if svn:ignore or other property was changed, but always set on copy/rename (path_from != NULL)
             if (fetchIgnoreProps(&svnignore, pool, key, fs_root) != EXIT_SUCCESS) {
@@ -946,7 +946,7 @@ int SvnRevision::exportInternal(const char *key, const svn_fs_path_change2_t *ch
         }
 
         // Add GitIgnore for empty directories (if GitIgnore was not set previously)
-        if (CommandLineParser::instance()->contains("empty-dirs") && ignoreSet == false) {
+        if (CommandLineParser::instance()->contains(QStringLiteral("empty-dirs")) && ignoreSet == false) {
             if (addGitIgnore(pool, key, path, fs_root, txn) == EXIT_SUCCESS) {
                 return EXIT_SUCCESS;
             }
@@ -955,7 +955,7 @@ int SvnRevision::exportInternal(const char *key, const svn_fs_path_change2_t *ch
         if (dumpDirectory) {
             recursiveDumpDir(txn, fs, fs_root, key, path, pool, revnum, rule, matchRules, ruledebug, ignoreSet);
 
-            if (CommandLineParser::instance()->contains("empty-dirs")) {
+            if (CommandLineParser::instance()->contains(QStringLiteral("empty-dirs"))) {
                 addGitIgnoreOnBranch(pool, key, path, fs_root, txn);
             }
         }
@@ -983,7 +983,7 @@ int SvnRevision::recursiveDumpDir(Repository::Transaction *txn, svn_fs_t *fs, sv
         return EXIT_SUCCESS;
     }
 
-    if ((ignoreSet == false) && CommandLineParser::instance()->contains("svn-ignore")) {
+    if ((ignoreSet == false) && CommandLineParser::instance()->contains(QStringLiteral("svn-ignore"))) {
         QString svnignore;
         if (fetchIgnoreProps(&svnignore, pool, pathname, fs_root) != EXIT_SUCCESS) {
             qWarning() << "Error fetching svn-properties (" << pathname << ")";
@@ -1151,7 +1151,7 @@ int SvnRevision::addGitIgnore(apr_pool_t *pool, const char *key, QString path,
         // if svn:ignore could not be determined, stay safe and do not overwrite the .gitignore file
         // even if then an empty directory might be missing
         QString svnignore;
-        if (CommandLineParser::instance()->contains("svn-ignore")) {
+        if (CommandLineParser::instance()->contains(QStringLiteral("svn-ignore"))) {
             if (fetchIgnoreProps(&svnignore, pool, key, fs_root) != EXIT_SUCCESS) {
                 qWarning() << "Error fetching svn-properties (" << key << ")";
                 return EXIT_FAILURE;
@@ -1165,7 +1165,7 @@ int SvnRevision::addGitIgnore(apr_pool_t *pool, const char *key, QString path,
     QString gitIgnorePath = path == "/" ? ".gitignore" : path + ".gitignore";
     if (content) {
         QIODevice *io = txn->addFile(gitIgnorePath, 33188, strlen(content));
-        if (!CommandLineParser::instance()->contains("dry-run")) {
+        if (!CommandLineParser::instance()->contains(QStringLiteral("dry-run"))) {
             io->write(content);
             io->putChar('\n');
         }
@@ -1173,11 +1173,11 @@ int SvnRevision::addGitIgnore(apr_pool_t *pool, const char *key, QString path,
         // no empty placeholder .gitignore for repository root
         // this should be handled previously already, just a
         // security measure here.
-        if (path == "/") {
+        if (path == QLatin1String("/")) {
             return EXIT_FAILURE;
         }
         QIODevice *io = txn->addFile(gitIgnorePath, 33188, 0);
-        if (!CommandLineParser::instance()->contains("dry-run")) {
+        if (!CommandLineParser::instance()->contains(QStringLiteral("dry-run"))) {
             io->putChar('\n');
         }
     }
@@ -1188,12 +1188,12 @@ int SvnRevision::addGitIgnore(apr_pool_t *pool, const char *key, QString path,
 int SvnRevision::checkParentNotEmpty(apr_pool_t *pool, const char *key, QString path,
                                      svn_fs_root_t *fs_root, Repository::Transaction *txn)
 {
-    if (!CommandLineParser::instance()->contains("empty-dirs")) {
+    if (!CommandLineParser::instance()->contains(QStringLiteral("empty-dirs"))) {
       return EXIT_FAILURE;
     }
-    QString slash = "/";
+    const QChar slash = '/';
     QString qkey = QString::fromUtf8(key);
-    while (qkey.endsWith('/'))
+    while (qkey.endsWith(slash))
         qkey = qkey.mid(0, qkey.length()-1);
     int index = qkey.lastIndexOf(slash);
     if (index == -1) {
@@ -1223,7 +1223,7 @@ int SvnRevision::checkParentNotEmpty(apr_pool_t *pool, const char *key, QString 
     // if svn:ignore could not be determined, stay safe and do not overwrite the .gitignore file
     // even if then an empty directory might be missing
     QString svnignore;
-    if (CommandLineParser::instance()->contains("svn-ignore")) {
+    if (CommandLineParser::instance()->contains(QStringLiteral("svn-ignore"))) {
         if (fetchIgnoreProps(&svnignore, pool, parentKey.toStdString().c_str(), fs_root) != EXIT_SUCCESS) {
             qWarning() << "Error fetching svn-properties (" << parentKey << ")";
             return EXIT_FAILURE;
@@ -1235,7 +1235,7 @@ int SvnRevision::checkParentNotEmpty(apr_pool_t *pool, const char *key, QString 
     // Add gitignore-File
     QString gitIgnorePath = parentPath + "/.gitignore";
     QIODevice *io = txn->addFile(gitIgnorePath, 33188, 0);
-    if (!CommandLineParser::instance()->contains("dry-run")) {
+    if (!CommandLineParser::instance()->contains(QStringLiteral("dry-run"))) {
       io->putChar('\n');
     }
 
@@ -1243,12 +1243,12 @@ int SvnRevision::checkParentNotEmpty(apr_pool_t *pool, const char *key, QString 
 }
 
 int SvnRevision::checkParentNoLongerEmpty(apr_pool_t *pool, const char *key, QString path, Repository::Transaction *txn) {
-    if (!CommandLineParser::instance()->contains("empty-dirs")) {
+    if (!CommandLineParser::instance()->contains(QStringLiteral("empty-dirs"))) {
       return EXIT_FAILURE;
     }
-    QString slash = "/";
+    const QChar slash = '/';
     QString qkey = QString::fromUtf8(key);
-    while (qkey.endsWith('/'))
+    while (qkey.endsWith(slash))
         qkey = qkey.mid(0, qkey.length()-1);
     int index = qkey.lastIndexOf(slash);
     if (index == -1) {
@@ -1288,7 +1288,7 @@ int SvnRevision::checkParentNoLongerEmpty(apr_pool_t *pool, const char *key, QSt
     // if svn:ignore could not be determined, stay safe and do not consider the directory empty
     // even if then an empty .gitignore might be left over
     QString svnignore;
-    if (CommandLineParser::instance()->contains("svn-ignore")) {
+    if (CommandLineParser::instance()->contains(QStringLiteral("svn-ignore"))) {
         if (fetchIgnoreProps(&svnignore, pool, parentKey.toStdString().c_str(), previous_fs_root) != EXIT_SUCCESS) {
             qWarning() << "Error fetching svn-properties (" << parentKey << ")";
             return EXIT_FAILURE;
@@ -1331,11 +1331,11 @@ int SvnRevision::addGitIgnoreOnBranch(apr_pool_t *pool, QString key, QString pat
 #endif
     while (i.hasNext()) {
         i.next();
-        QString entryName = key + "/" + i.key();
+        QString entryName = key + QLatin1String("/") + i.key();
         QString entryFinalName = path + QString::fromUtf8(i.key());
 
         if (i.value() == svn_node_dir) {
-            entryFinalName += "/";
+            entryFinalName += QLatin1String("/");
             if (addGitIgnore(pool, entryName.toStdString().c_str(), entryFinalName, fs_root, txn) == EXIT_FAILURE) {
                 addGitIgnoreOnBranch(pool, entryName, entryFinalName, fs_root, txn);
             }


### PR DESCRIPTION
There are several fixes here:
* bump minimal version to Qt5.15. This allows to remove some deprecated warnings on QMultiMap (unfortunately QMultiMapIterator is only Qt6 so we cannot remove at these places)
* Run multiple [clazy](https://invent.kde.org/sdk/clazy) checks to reduce the memory allocations.

I've created one commit per check, feel free to merge them if you feel it more appropriate