### PR TITLE
Workaround tar 1.35+dfsg-3ubuntu0.3 regressions with `--one-top-level` to fix CI

### DIFF
--- a/test/common.bash
+++ b/test/common.bash
@@ -14,7 +14,8 @@ commonSetup() {
     SVN_REPO="$TEST_TEMP_DIR/svn-repo"
     SVN_WORKTREE="$TEST_TEMP_DIR/svn-worktree"
 
-    tar xf "$BATS_TEST_DIRNAME/base-fixture.tar" --one-top-level="$SVN_REPO"
+    mkdir "$SVN_REPO"
+    tar xf "$BATS_TEST_DIRNAME/base-fixture.tar" -C "$SVN_REPO"
     svn checkout "file:///$SVN_REPO" "$SVN_WORKTREE"
     cd "$SVN_WORKTREE"
 }


### PR DESCRIPTION
This works around regressions from CVE-2026-5704 fixes in tar 1.35+dfsg-3ubuntu0.3.

The symptom was:

```console
# ./test.sh --no-make
tar: [..]/svn-repo: Cannot mkdir: Invalid cross-device link
tar: [..]/svn-repo/db: Cannot mkdir: Invalid cross-device link
tar: [..]/svn-repo/db/current: Cannot open: Invalid cross-device link
tar: [..]/svn-repo/db/format: Cannot open: Invalid cross-device link
tar: [..]/svn-repo/db/fs-type: Cannot open: Invalid cross-device link
tar: [..]/svn-repo/db/min-unpacked-rev: Cannot open: Invalid cross-device link
tar: [..]/svn-repo/db/revprops: Cannot mkdir: Invalid cross-device link
tar: [..]/svn-repo/db/revprops/0: Cannot mkdir: Invalid cross-device link
tar: [..]/svn-repo/db/revprops/0/0: Cannot open: Invalid cross-device link
tar: [..]/svn-repo/db/revs: Cannot mkdir: Invalid cross-device link
tar: [..]/svn-repo/db/revs/0: Cannot mkdir: Invalid cross-device link
tar: [..]/svn-repo/db/revs/0/0: Cannot open: Invalid cross-device link
tar: [..]/svn-repo/db/transactions: Cannot mkdir: Invalid cross-device link
tar: [..]/svn-repo/db/txn-current: Cannot open: Invalid cross-device link
tar: [..]/svn-repo/db/txn-current-lock: Cannot open: Invalid cross-device link
tar: [..]/svn-repo/db/txn-protorevs: Cannot mkdir: Invalid cross-device link
tar: [..]/svn-repo/db/uuid: Cannot open: Invalid cross-device link
tar: [..]/svn-repo/db/write-lock: Cannot open: Invalid cross-device link
tar: [..]/svn-repo/format: Cannot open: Invalid cross-device link
tar: [..]/svn-repo/locks: Cannot mkdir: Invalid cross-device link
tar: [..]/svn-repo/locks/db-logs.lock: Cannot open: Invalid cross-device link
tar: [..]/svn-repo/locks/db.lock: Cannot open: Invalid cross-device link
tar: [..]/svn-repo/README.txt: Cannot open: Invalid cross-device link
tar: Exiting with failure status due to previous errors
```

CC @kirotawa @canonical-leosilvab @hannob